### PR TITLE
support sciml blue and yas styleguides

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--allow-multiple-documents, --unsafe] # These options are here because of the copier.yml file
       - id: end-of-file-fixer
       - id: file-contents-sorter
-        files: .JuliaFormatter.toml
+        files: .JuliaFormatter.toml$
         args: [--unique]
       - id: mixed-line-ending
         args: [--fix=lf]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- New question: `StyleGuide`, which lets the user choose among popular styleguides (SciML, Blue, YAS) (#440)
+
+### Changed
+
+- `JuliaIndentation` is asked only if no predefined style guide is selected (#440)
+
 ## [0.13.0] - 2024-10-11
 
 BREAKING NOTICE (MANUAL INTERVENTION REQUIRED):

--- a/copier/essential.yml
+++ b/copier/essential.yml
@@ -96,23 +96,10 @@ LicenseCopyrightHolders:
   help: License Copyright Holders (Added in front of "Copyright (c) " notices, when applicable)
   default: "{{ Authors | regex_replace('\\s*([^,]*)\\s*<[^,]*>[^,]*', '\\\\1') | regex_replace('\\s*,\\s*', ', ') | trim }}"
   validator: "{% if LicenseCopyrightHolders | length == 0%}Can't be empty{% endif %}"
-<<<<<<< HEAD
   description: |
     Some license files include a "Copyright (c) <LicenseCopyrightHolders>" notice.
     Defaults to names in the Authors question, if they follow the recommended format.
     For instance, if the Authors field is "NAME1 <EMAIL1>,NAME2 <EMAIL2>", this will default to "NAME1, NAME2".
-=======
-
-StyleGuide:
-  type: str
-  help: Julia formatting style (Do you want to follow any particular style guide?)
-  choices:
-    None (use BestieTemplate default formatting): none
-    Blue Style: blue
-    YAS Style: yas
-    SciML Style: sciml
-  default: none
->>>>>>> c488d85 (Update copier/essential.yml)
 
 Indentation:
   when: false

--- a/copier/essential.yml
+++ b/copier/essential.yml
@@ -96,10 +96,23 @@ LicenseCopyrightHolders:
   help: License Copyright Holders (Added in front of "Copyright (c) " notices, when applicable)
   default: "{{ Authors | regex_replace('\\s*([^,]*)\\s*<[^,]*>[^,]*', '\\\\1') | regex_replace('\\s*,\\s*', ', ') | trim }}"
   validator: "{% if LicenseCopyrightHolders | length == 0%}Can't be empty{% endif %}"
+<<<<<<< HEAD
   description: |
     Some license files include a "Copyright (c) <LicenseCopyrightHolders>" notice.
     Defaults to names in the Authors question, if they follow the recommended format.
     For instance, if the Authors field is "NAME1 <EMAIL1>,NAME2 <EMAIL2>", this will default to "NAME1, NAME2".
+=======
+
+StyleGuide:
+  type: str
+  help: Julia formatting style (Do you want to follow any particular style guide?)
+  choices:
+    None (use BestieTemplate default formatting): none
+    Blue Style: blue
+    YAS Style: yas
+    SciML Style: sciml
+  default: none
+>>>>>>> c488d85 (Update copier/essential.yml)
 
 Indentation:
   when: false

--- a/template/.JuliaFormatter.toml.jinja
+++ b/template/.JuliaFormatter.toml.jinja
@@ -1,3 +1,7 @@
+{% if StyleGuide == 'none' %}
 indent = {{ JuliaIndentation }}
 margin = 92
 normalize_line_endings = "unix"
+{% else %}
+style = "{{ StyleGuide }}"
+{% endif %}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -14,6 +14,7 @@
 {% if AddCodeOfConduct -%}
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 {% endif -%}
+{% if StyleGuide == 'sciml' %}[![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle){% endif %}{% if StyleGuide == 'blue' %}[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/JuliaDiff/BlueStyle){% endif %}
 {% if AddAllcontributors -%}
 [![All Contributors](https://img.shields.io/github/all-contributors/{{ PackageOwner }}/{{ PackageName }}.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square)](#contributors)
 {% endif -%}


### PR DESCRIPTION
PR changes summary:

- Introduce a new question that asks whether the user wants to follow an established styleguide, offering [SciML Style](https://github.com/SciML/SciMLStyle), [Blue Style](https://github.com/JuliaDiff/BlueStyle) and [YAS Style](https://github.com/jrevels/YASGuide) as options (same of PkgTemplates). By default, no styleguide is selected
- Now the question about indentation is made conditional and asked only if the user selects "no styleguide" since all other three are opinionated in what to follow (4 white spaces, which is the default choice anyway). An alternative could be to always ask the question about indentation and allow things like "sciml but I use indentation 2".
- If Blue style or Sciml style is chosen, the corresponding badge is added to the README. As far as I can tell, YAS does not have an official badge.

## Related issues

Closes #424 

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [x] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
