### PR TITLE
Fix Windows failures by fixing shell to bash in workflow

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -47,8 +47,9 @@ jobs:
           git checkout origin/main
           git branch --track main origin/main
           git checkout this-pr
-      - name: Create ENV if necessary
+      - name: Create BESTIE_SKIP_UPDATE_TEST=yes if necessary
         if: github.ref != 'refs/heads/main'
+        shell: bash
         run: |
           if git --no-pager log main..HEAD | grep -q BESTIE_SKIP_UPDATE_TEST; then
             echo "BESTIE_SKIP_UPDATE_TEST=yes" >> $GITHUB_ENV


### PR DESCRIPTION
Windows fails in the latest tests due to not being able to run the bash
commands to check whether to skip update tests (introduced in #486).
It was not executed in the `main` branch, so it only showed up when
creating a release.
