### PR TITLE
ignore `@cite` in link checks

### DIFF
--- a/template/.lychee.toml.jinja
+++ b/template/.lychee.toml.jinja
@@ -1,5 +1,6 @@
 exclude = [
   "@ref",
+  "@cite",
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://doi.org/FIXME$",
   "^https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/stable$",


### PR DESCRIPTION
[DocuemnterCitations.jl](https://github.com/JuliaDocs/DocumenterCitations.jl) allows to haver latex references and citations, using the syntax

```julia
[bibtex_id](@cite)
```

which currently would cause the links check to fail (see [this example](https://github.com/lucaferranti/DedekindCutArithmetic.jl/actions/runs/11514528897/job/32053329191?pr=3#step:3:108) ). This PR adds `@cite` to excluded links, similar to `@ref` to bypass this problem.


## Checklist

- [x] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
