### PR TITLE
Implement a new strategy "Recommended and ask extras"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ BREAKING NOTICE:
 
 - The link-checker now uses lychee version 2, which might lead to failures. See <https://github.com/JuliaBesties/BestieTemplate.jl/pull/495> for the release notes.
 
+### Added
+
+- Create a new strategy to allow users to install all recommended and get asked additional questions.
+
 ### Changed
 
 - Update action version

--- a/copier/ci.yml
+++ b/copier/ci.yml
@@ -27,7 +27,7 @@ AddWinToCI:
     Defaults to yes for the recommended strategy, or no otherwise.
 
 RunJuliaNightlyOnCI:
-  when: "{{ AnswerStrategy == 'ask' }}"
+  when: "{{ AnswerStrategy == 'ask' or AnswerStrategy == 'recommended-ask' }}"
   type: bool
   help: Julia nightly CI test (Package tests run on Julia version {{ JuliaMinVersion }} and on the latest stable release. Do you also want to run them on the nightly version?)
   default: false
@@ -36,7 +36,7 @@ RunJuliaNightlyOnCI:
     Defaults to no.
 
 UseCirrusCI:
-  when: "{{ AnswerStrategy == 'ask' }}"
+  when: "{{ AnswerStrategy == 'ask' or AnswerStrategy == 'recommended-ask' }}"
   type: bool
   help: FreeBSD CI test with CirrusCI (Add CirrusCI to run the package tests on FreeBSD?)
   default: false
@@ -45,7 +45,7 @@ UseCirrusCI:
     Defaults to no.
 
 AddCopierCI:
-  when: "{{ AnswerStrategy == 'ask' }}"
+  when: "{{ AnswerStrategy == 'ask' or AnswerStrategy == 'recommended-ask' }}"
   type: bool
   help: Copier.yml (Add workflow to check for template updates? This is a work in progress workflow that checks whether there has been an update to the template and automatically create a pull request)
   default: false

--- a/copier/code-quality.yml
+++ b/copier/code-quality.yml
@@ -39,7 +39,7 @@ JuliaIndentation:
     For existing packages, this will be inferred from the indent value in the `.JuliaFormatter.toml` file.
 
 MarkdownIndentation:
-  when: "{{ AnswerStrategy == 'ask' }}"
+  when: "{{ AnswerStrategy != 'minimum' }}"
   type: int
   help: Indentation length for Markdown files (Used in .markdownlint.json and .editorconfig)
   validator: "{% if MarkdownIndentation <= 0 %}Indentation must be positive{% endif %}"
@@ -56,7 +56,7 @@ MarkdownIndentation:
     For existing packages, this will be inferred from the indent value in the `.JuliaFormatter.toml` file.
 
 ConfigIndentation:
-  when: "{{ AnswerStrategy == 'ask' }}"
+  when: "{{ AnswerStrategy != 'minimum' }}"
   type: int
   help: Indentation length for configuration files (Used to format YAML and JSON files)
   validator: "{% if ConfigIndentation <= 0 %}Indentation must be positive{% endif %}"

--- a/copier/strategy.yml
+++ b/copier/strategy.yml
@@ -3,13 +3,15 @@ AnswerStrategy:
   default: recommended
   help: "Strategy for optional questions (You can see the full list of questions in https://JuliaBesties.github.io/BestieTemplate.jl/dev/30-questions/)"
   choices:
-    Recommended (Our defaults): "recommended"
+    Recommended only: "recommended"
+    Recommended and ask other options: "recommended-ask"
     Minimum (Answer no to any addition): "minimum"
     Ask me (Ask all questions): "ask"
   description: |
     This defines how to deal with the rest of the questions.
-    The `minimum` strategy answers "no" to every question. This is not the same as a bare-bones package. The resulting package will have the minimum amount of best practices that we recommend.
-    The `recommended` strategy uses all our recommended best practices, which might be overwhelming for anyone. See the answers below this step to see all the options. This is not the same as saying "yes" to everything.
-    The `ask` strategy does not select anything from the list below. All questions will be asked.
-    Notice that some options are only available through the `ask` strategy, or by explicitly passing them to the Bestie command.
+    The "minimum" strategy answers "no" to every question. This is not the same as a bare-bones package. The resulting package will have the minimum amount of best practices that we recommend.
+    Both "recommended" strategies use all our recommended best practices. You then have the option to ignore or ask the optional questions. The optional questions include features that are being tested or that are too specific to be recommended.
+    The "recommended" strategy might be overwhelming for most people. See the answers below this step to see all the options. This is not the same as saying "yes" to everything.
+    The "ask" strategy does not select anything from the list below. All questions will be asked.
+    Notice that some options are only available through the "ask" or "recommended and ask" strategies, or by explicitly passing them to the Bestie command.
     Defaults to the "recommended" strategy.

--- a/docs/src/10-full-guide.md
+++ b/docs/src/10-full-guide.md
@@ -27,7 +27,7 @@ If you decide to gradually adopt, do this:
 
 1. Follow the relevant application section for [New](@ref new_package) or [Existing](@ref existing_package).
 1. Remember to select the "Minimum" optional questions.
-1. Follow the [Update section](@ref updating_package), change your answer from "Minimum" to "Recommended" or "Ask me".
+1. Follow the [Update section](@ref updating_package), change your answer from "Minimum" to one of the others.
 
 ### Things to install
 

--- a/docs/src/20-explanation.md
+++ b/docs/src/20-explanation.md
@@ -63,11 +63,12 @@ Furthermore, they can keep reaping benefits when we create new versions of the t
 
 Let's dive into the details of the template now.
 
-### Recommended vs Minimum vs Others (hidden)
+### Recommended vs Minimum
 
 The template contains a few required questions and then asks you whether you would like to use
 
-- The "recommended" options, which include our current recommendation for best practices;
+- The "recommended only" options, which include our current recommendation for best practices;
+- The "recommended and ask extra" options, which include our current recommendation for best practices and you get asked extra questions;
 - The "minimum" options, which answers "no" to everything, but still leaves you with a decent package to start; or
 - The option to answer every optional question individually.
 
@@ -102,11 +103,12 @@ Our **loose** criteria to make something part of the recommended, but not minimu
 - It creates friction - which is good to ensure quality but slows developement (e.g., issue templates).
 
 Finally, there are **other optional features**.
-These are neither recommended nor part of the minimum template, which means that unless you (know and) set them explicitly, you are not using them.
+These are neither recommended nor part of the minimum template, which means that you need to use one of the strategies that ask extra questions ("Recommended ans ask extra" or "Ask") or set them explicitly.
 
 The **loose** criteria to make something not recommended, nor minimum, is:
 
 - It is a best practice, but for a niche audience (e.g., `.cirrus.yml` for testing on FreeBSD);
+- It is potentially disruptive (e.g., testing on Nightly)
 
 To see all the questions, head to [Questions](@ref).
 

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -242,7 +242,8 @@ Find an appropriate place to add the question. Comments help identify the option
 Follow the other questions style and syntax. The gist of it is that you need:
 
 - A `CamelCase` name.
-- `when: "{{ AnswerStrategy == 'ask' }}"` if the question is optional.
+- `when: "{{ AnswerStrategy == 'ask' }}"` if the question is optional but should be automatically selected for "Recommended only".
+- `when: "{{ AnswerStrategy == 'ask' or AnswerStrategy == 'recommended-ask' }}"` if the question is extra.
 - A `type`.
 - A `help: Short description or title (Longer description and details)`.
 - A `default`, if the question is optional.

--- a/src/api.jl
+++ b/src/api.jl
@@ -24,7 +24,8 @@ function _copy(src_path, dst_path, data; kwargs...)
   First, some **required** questions will need to be filled.
   Then, you will have the option of selecting
 
-  - The _recommended_ options, which includes our current _best practices recommendations_;
+  - The _recommended only_ options, which includes our current _best practices recommendations_;
+  - The _recommended and possible extras_ options, which is the same as _recommended but asks additional questions that are not in recommended;
   - The _minimum_ options, which will answer _no_ to everything, but still give you what
     we consider the minimum best practices you need to get started; or
   - Answer every optional question.

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -36,9 +36,12 @@ const strategy_minimum = merge(
   ),
 )
 
-const strategy_recommended = merge(strategy_minimum, Dict("AnswerStrategy" => "recommended"))
+const strategy_recommended_only = merge(strategy_minimum, Dict("AnswerStrategy" => "recommended"))
 
-const strategy_ask = merge(strategy_recommended, Dict("AnswerStrategy" => "ask"))
+const strategy_recommended_ask =
+  merge(strategy_minimum, Dict("AnswerStrategy" => "recommended-ask"))
+
+const strategy_ask = merge(strategy_minimum, Dict("AnswerStrategy" => "ask"))
 
 const optional_questions_with_default = Dict(
   "AddPrecommit" => true,
@@ -61,9 +64,9 @@ const optional_questions_with_default = Dict(
 const strategy_ask_default = merge(strategy_ask, optional_questions_with_default)
 
 const strategy_ask_and_say_no =
-  merge(strategy_recommended, Dict(k => false for k in keys(optional_questions_with_default)))
+  merge(strategy_recommended_only, Dict(k => false for k in keys(optional_questions_with_default)))
 
 const strategy_ask_and_say_yes =
-  merge(strategy_recommended, Dict(k => true for k in keys(optional_questions_with_default)))
+  merge(strategy_recommended_only, Dict(k => true for k in keys(optional_questions_with_default)))
 
 end

--- a/src/debug/helper.jl
+++ b/src/debug/helper.jl
@@ -30,8 +30,10 @@ function dbg_data(data_choice, _data = Dict())
     Data.minimum_defaults
   elseif data_choice in [:minimum, :min]
     Data.strategy_minimum
-  elseif data_choice in [:recommended, :rec]
-    Data.strategy_recommended
+  elseif data_choice in [:recommended, (:recommended_only):rec, :rec_only]
+    Data.strategy_recommended_only
+  elseif data_choice in [:recommended_ask, :rec_ask]
+    Data.strategy_recommended_ask
   elseif data_choice in [:ask]
     Data.strategy_ask
   elseif data_choice in [:ask_default]


### PR DESCRIPTION
Rename the "Recommended" approach to "Recommended only".
Add a new "recommended-ask" strategy to use the recommended answers
and additionally ask whether the user wants the non-recommended things.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #490

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
