### PR TITLE
Change permissions of project when generating using :local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- When generating from a local copy, change permissions of the resulting project to prevent it being read-only (#532).
+
 ## [0.16.0] - 2025-05-30
 
 BREAKING NOTICE:

--- a/src/BestieTemplate.jl
+++ b/src/BestieTemplate.jl
@@ -30,6 +30,7 @@ using UUIDs: UUIDs
 using YAML: YAML
 
 include("Copier.jl")
+include("utils.jl")
 include("api.jl")
 include("debug/Debug.jl")
 include("friendly.jl")

--- a/src/friendly.jl
+++ b/src/friendly.jl
@@ -59,8 +59,10 @@ function new_pkg_quick(
     error("Unknown strategy: $strategy")
   end
 
+  change_permissions = false
   # Ensure valid template source
   template_path = if template_source == :local
+    change_permissions = true
     pkgdir(BestieTemplate)
   elseif template_source == :online
     "https://github.com/JuliaBesties/BestieTemplate.jl"
@@ -93,6 +95,7 @@ function new_pkg_quick(
     data;
     defaults = true,
     quiet = true,
+    change_permissions = change_permissions,
     kwargs...,
     extra_args...,
   )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,18 @@
+"""
+    change_project_permissions(project_path)
+
+Change the permission of all files in the `project_path` to 644 and folders to 755.
+"""
+function change_project_permissions(project_path)
+  @assert project_path != "."
+  for (root, dirs, files) in walkdir(project_path)
+    for dir in dirs
+      chmod(joinpath(root, dir), 0o755)
+    end
+    for file in files
+      chmod(joinpath(root, file), 0o644)
+    end
+  end
+
+  return nothing
+end


### PR DESCRIPTION
The installed BestieTemplate will usually be in the .julia folder, read-only.
This leads to the generated package being read-only as well.
To fix this, we change the permissions of the generated package when :local
is used.

Fixed #532
