### PR TITLE
Change default markdownlint configuration MD024.siblings_only to true

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,9 @@
     "line_length": 1000,
     "tables": false
   },
+  "MD024": {
+    "siblings_only": true
+  },
   "MD033": false,
   "MD041": false,
   "default": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
-<!-- markdownlint-disable MD024 -->
-
 ## [Unreleased]
 
 BREAKING NOTICE:
 
 - The pre-commit autoupdate CI is no longer part of the `Precommit` question, and defaults to `false`. To keep the workflow, add `"AddPrecommitUpdateCI" => true` to your data argument, or ask to "Review all excluded items" in the interactive mode.
+- The default markdownlint configuration now accepts duplicate headers when the headers are on different levels. This improves the experience of some CHANGELOG formats. To revert this locally change `siblings_only` to false in `.markdownlint.json` (i.e., `"MD024": { "siblings_only": false }`). In that case, CHANGELOG will fail to pass this rule, but you can manually add `<!-- markdownlint-disable MD024 -->` in the beginning of the file to skip it.
 
 ### Added
 
@@ -21,6 +20,7 @@ BREAKING NOTICE:
 ### Changed
 
 - The pre-commit autoupdate CI is no longer part of the `Precommit` question, and defaults to `false` (advanced) (#503)
+- The default markdownlint configuration (in `.markdownlist.json`) now has `MD024.siblings_only = true` (#505)
 
 ## [0.16.2] - 2025-05-31
 

--- a/template/{% if AddFormatterAndLinterConfigFiles %}.markdownlint.json{% endif %}.jinja
+++ b/template/{% if AddFormatterAndLinterConfigFiles %}.markdownlint.json{% endif %}.jinja
@@ -7,6 +7,9 @@
     "line_length": 1000,
     "tables": false
   },
+  "MD024": {
+    "siblings_only": true
+  },
   "MD033": false,
   "MD041": false,
   "default": true


### PR DESCRIPTION
This will allow duplicate headers if they have different parents.

This might be a BREAKING CHANGE if you are relying on this behaviour.
To revert, change `siblings_only` to `false` in `.markdownlint.json`.
You can then manually add `<!-- markdownlint-disable MD024 -->` to
explicitly disable it in some files.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #505

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
