### PR TITLE
Add configuration for Codecov in the template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ BREAKING NOTICE:
 
 - Automatic list of docs pages should now include subsections from folders (#536)
 - New question: `AddPrecommitUpdateCI` to make the pre-commit autoupdate CI optional (#503)
+- Configuration for Codecov, `codecov.yml`, was added to the template (#494)
 
 ### Changed
 

--- a/template/{% if AddTestCI %}codecov.yml{% endif %}.jinja
+++ b/template/{% if AddTestCI %}codecov.yml{% endif %}.jinja
@@ -8,5 +8,3 @@ coverage:
       default:
         target: 90%
   range: "80...90" # Yellow within this range
-ignore:
-  - "src/debug"


### PR DESCRIPTION
The file codecov.yml contains configuration of the required levels
of coverage to consider it "passing".

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #494

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
