### PR TITLE
Fix Windows test failures and add pr-test-all label support

### DIFF
--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -11,7 +11,7 @@ on:
       - "copier.yml"
       - "template/**"
       - ".github/workflows/*Test*"
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   # Skip intermediate builds: always.
@@ -23,10 +23,24 @@ jobs:
   test:
     uses: ./.github/workflows/ReusableTest.yml
     with:
-      os: ubuntu-latest
+      os: ${{ matrix.os }}
       version: "1"
       arch: x64
       allow_failure: false
-      run_codecov: true
+      run_codecov: ${{ matrix.os == 'ubuntu-latest' }}
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        has_test_all_label:
+          - ${{ contains(github.event.pull_request.labels.*.name, 'pr-test-all') }}
+        exclude: # If there is no label (`false`), the other OSs are excluded. If there is label (`true`), exclude doesn't match anything
+          - has_test_all_label: false
+            os: macOS-latest
+          - has_test_all_label: false
+            os: windows-latest

--- a/test/test-bad-usage-and-errors.jl
+++ b/test/test-bad-usage-and-errors.jl
@@ -51,18 +51,23 @@ end
   # clone loses the rmtree race (the copy itself has already succeeded).
   function _cleanup_race_exception(filename)
     try
-      PythonCall.pyexec("raise OSError(39, 'Directory not empty', '$filename')", @__MODULE__)
+      PythonCall.pyexec(
+        "raise OSError(39, 'Directory not empty', filename)",
+        @__MODULE__,
+        (; filename),
+      )
       error("unreachable")
     catch ex
       return ex
     end
   end
 
-  ex = _cleanup_race_exception("/tmp/copier._vcs.clone.test123/.git/objects")
-  @test Copier._copier_tempdir_from_exception(ex) == "/tmp/copier._vcs.clone.test123"
+  fake_clone_dir = joinpath("tmp", "copier._vcs.clone.test123")
+  ex = _cleanup_race_exception(joinpath(fake_clone_dir, ".git", "objects"))
+  @test Copier._copier_tempdir_from_exception(ex) == fake_clone_dir
 
   # OSError outside a copier temp clone is not swallowed
-  ex_other = _cleanup_race_exception("/tmp/some-other-dir/.git/objects")
+  ex_other = _cleanup_race_exception(joinpath("tmp", "some-other-dir", ".git", "objects"))
   @test isnothing(Copier._copier_tempdir_from_exception(ex_other))
   @test_throws PythonCall.PyException Copier._ignore_cleanup_race(() -> throw(ex_other))
 


### PR DESCRIPTION
## Changes

- **Fix Windows failures in the copier cleanup-race test** (fixes the red main CI): the test interpolated a file path into Python source, so Windows backslashes were parsed as string escapes (`SyntaxError: truncated \UXXXXXXXX escape`), and it compared `_copier_tempdir_from_exception` output against a hardcoded `/tmp/...` string while the function rebuilds the path with `joinpath` (backslashes on Windows). The filename is now passed to `pyexec` as a Python variable and the expected paths are built with `joinpath`.
- **Run TestOnPRs on all OSs when the `pr-test-all` label is present**: the workflow now triggers on `labeled` events and expands the matrix to ubuntu/macOS/windows when the PR carries the label (codecov still only on ubuntu).

The `pr-test-all` label has been created on the repo and is applied to this PR, so the full matrix should run here and verify the Windows fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)