### PR TITLE
Relax link-checker retry-related values

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,7 +3,8 @@ exclude = [
   "@[Cc]ite.*",
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://github.com/.*/compare/v.*HEAD$",
-  "^https://blog.esciencecenter.nl" # certificate error, hopefully fixed soon
+  "^https://blog.esciencecenter.nl", # certificate error, hopefully fixed soon
+  "^https://asciinema.org/*",
 ]
 
 exclude_path = [

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -10,3 +10,7 @@ exclude_path = [
   "docs/build",
   "test/conda-env"
 ]
+
+max_retries = 5
+retry_wait_time = 3
+timeout = 60


### PR DESCRIPTION
Try to help timeout errors in the link-checker. Shouldn't be
very helpful in general, but decreases the doubts related to
it.
