### PR TITLE
Prepare the first bestie-template PyPI release

### DIFF
--- a/.github/workflows/PublishPython.yml
+++ b/.github/workflows/PublishPython.yml
@@ -1,0 +1,66 @@
+name: PublishPython
+
+# Publishes the bestie-template Python package to PyPI on py-vX.Y.Z tags. The
+# prefix keeps these tags distinct from TagBot's vX.Y.Z: the Julia and Python
+# packages are versioned independently and released on different cadences.
+#
+# Auth is PyPI trusted publishing (OIDC), so there are no tokens in the repo.
+# The `pypi` GitHub environment must exist and be restricted to py-v* tags.
+
+on:
+  push:
+    tags:
+      - "py-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      # PyPI uploads are immutable, so a mismatch has to fail before publishing
+      - name: Check that the tag matches the project version
+        run: |
+          tag_version="${GITHUB_REF_NAME#py-v}"
+          project_version="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          if [ "$tag_version" != "$project_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject.toml version $project_version" >&2
+            exit 1
+          fi
+      # Builds the sdist, then the wheel from that sdist, which exercises both
+      - name: Build sdist and wheel
+        run: uv build
+      # --version proves the entry point and the installed metadata are sound;
+      # list-features proves hatch_build.py bundled the feature registry
+      - name: Smoke-test the wheel
+        run: |
+          uv run --isolated --no-project --with dist/*.whl bestie --version
+          uv run --isolated --no-project --with dist/*.whl bestie list-features --json > /dev/null
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: python/dist/
+          if-no-files-found: error
+
+  # Split from `build` so the OIDC token is only ever in scope for the upload,
+  # and so an environment reviewer approves an already-built, smoke-tested wheel
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bestie-template
+    permissions:
+      id-token: write # OIDC token for PyPI trusted publishing
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- New workflow `.github/workflows/PublishPython.yml`, publishing the `bestie-template` Python package to PyPI on `py-v*` tags via trusted publishing (no tokens)
+
+### Changed
+
+- The Python package `bestie-template` is now at version `0.1.0`, ready for its first PyPI release. Its version is independent of the Julia package's, since the two are released on different cadences
+- `python/pyproject.toml` now sets a one-week `exclude-newer` dependency cooldown
+
 ## [0.19.0] - 2026-08-02
 
 BREAKING NOTICE:

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -163,7 +163,7 @@ Aliases are entries with a single `alias_of = "other_feature"` key.
 ### [The Python package (`python/`)](@id python_package)
 
 `python/` holds `bestie-template`, a port of `add_feature` and `list_features` that needs no Julia, plus a `bestie` CLI over them.
-It is experimental and not yet published to PyPI.
+It is experimental, and published to PyPI as [`bestie-template`](https://pypi.org/p/bestie-template) (see [Making a new Python release](@ref)).
 
 ```bash
 cd python
@@ -352,6 +352,24 @@ After that, you only need to wait and verify:
 - After the release is create, a "docs" GitHub action will start for the tag.
 - After it passes, a deploy action will run.
 - After that runs, the [stable docs](https://JuliaBesties.github.io/BestieTemplate.jl/stable) should be updated. Check them and look for the version number.
+
+## Making a new Python release
+
+The `bestie-template` Python package (see [The Python package (`python/`)](@ref python_package)) is released independently of the Julia package, using `py-vx.y.z` tags.
+Only release it when something under `python/` changes, or when a feature is added, renamed, or removed in `features.toml`.
+
+Release BestieTemplate.jl first and wait for the tag, because the wheel bakes in `features.toml` at build time but resolves the template's latest tag at run time. Otherwise the wheel can advertise a feature that the latest tag does not have, and `bestie add-feature` fails.
+
+- Create a branch `python-release-x.y.z`
+- Update `version` in `python/pyproject.toml`, then run `cd python && uv lock`
+- Add a `CHANGELOG.md` entry under "Unreleased", without renaming the section (the changelog tracks the whole repository)
+- Create a commit "Release py-vx.y.z", push, create a PR, wait for it to pass, merge the PR.
+- Tag the merged commit on `main` with `py-vx.y.z` and push the tag. Tag `main` and not the branch: PyPI uploads are immutable, and a squash-merged branch commit is not in the history of `main`.
+
+After that, you only need to wait and verify:
+
+- The tag triggers the `PublishPython` workflow, which checks the tag against the version, builds and smoke-tests the wheel, then waits on the `pypi` environment. Approve the deployment if it requires reviewers.
+- Check <https://pypi.org/p/bestie-template>, then verify with `uvx --from bestie-template==x.y.z bestie --version`.
 
 ## Additions to the templates
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bestie-template"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Python interface to the BestieTemplate copier template: add template features to Julia packages without Julia"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -31,6 +31,11 @@ Documentation = "https://JuliaBesties.github.io/BestieTemplate.jl"
 
 [dependency-groups]
 dev = ["pytest>=8"]
+
+# Dependency cooldown: ignore releases younger than the window, so a regression
+# or a compromised upload has time to be caught before we resolve against it
+[tool.uv]
+exclude-newer = "1 week"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/bestie_template"]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2,13 +2,17 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "annotated-doc"
-version = "0.0.5"
+version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -22,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "bestie-template"
-version = "0.1.0.dev0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },
@@ -278,14 +282,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.53"
+version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add the PublishPython workflow, which builds and smoke-tests the sdist and
wheel on py-v* tags and uploads them with PyPI trusted publishing, gated on
the pypi environment. Bump the Python package to 0.1.0, add a one-week
exclude-newer dependency cooldown, and document the release process.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
