### PR TITLE
Release py-v0.1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Julia wrapper around the Python [Copier](https://copier.readthedocs.io) template
 
 **Template (`template/`)** — Jinja2 files for generated packages.
 
-**Python package (`python/`)** — `bestie-template`, a port of `add_feature`/`list_features` that needs no Julia (experimental, unpublished; see issue #617). It reads the same repo-root `features.toml`, so a new feature needs no Python code — only the name added to `test_feature_names` in `python/tests/test_features.py`, which pins the feature set as a drift guard.
+**Python package (`python/`)** — `bestie-template`, a port of `add_feature`/`list_features` that needs no Julia (experimental; published to PyPI as `bestie-template`, see issue #617). It reads the same repo-root `features.toml`, so a new feature needs no Python code — only the name added to `test_feature_names` in `python/tests/test_features.py`, which pins the feature set as a drift guard.
 
 - Conditional file/dir inclusion via the filename: `{% if Condition %}filename{% endif %}.jinja`
 - Variable substitution in content: `{{ VariableName }}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning].
 
 ### Changed
 
-- The Python package `bestie-template` is now at version `0.1.0`, ready for its first PyPI release. Its version is independent of the Julia package's, since the two are released on different cadences
+- The Python package `bestie-template` is now at version `0.1.1`. Its version is independent of the Julia package's, since the two are released on different cadences
+- `bestie-template` installs a `bestie-template` command as an alias of `bestie`, so `uvx bestie-template ...` works without `--from`
+- The documentation, the `bestie-features` skill and `python/README.md` now install `bestie-template` from PyPI instead of from the git repository
+- The README and the full guide now mention the `bestie-features` agent skill and how to install it with `npx skills add JuliaBesties/BestieTemplate.jl`
 - `python/pyproject.toml` now sets a one-week `exclude-newer` dependency cooldown
 
 ## [0.19.0] - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ please note that `"YourPackage.jl"` can either be a fresh new package or an exis
 
 If you like what you see, check the [full usage guide](https://JuliaBesties.github.io/BestieTemplate.jl/stable/10-guides/10-full-guide/).
 
+## Without Julia, or from an AI coding agent
+
+Individual features of the template (`AGENTS.md`, changelog, Dependabot, pre-commit, …) can be added to an existing package without installing Julia, using the experimental [`bestie-template`](https://pypi.org/p/bestie-template) Python package.
+With [uv](https://docs.astral.sh/uv/) installed, no install step is needed:
+
+```sh
+uvx --from bestie-template bestie list-features
+uvx --from bestie-template bestie add-feature changelog,dependabot path/to/MyPackage.jl
+```
+
+For AI coding agents, the same workflow is packaged as the [`bestie-features` skill](skills/bestie-features/SKILL.md), which is installable with
+
+```sh
+npx skills add JuliaBesties/BestieTemplate.jl
+```
+
+See [skills.sh](https://www.skills.sh) for what agent skills are and which agents support them.
+
 ## Users and Examples
 
 The following are users and examples of repos using this template, or other templates based on it.

--- a/docs/src/10-guides/10-full-guide.md
+++ b/docs/src/10-guides/10-full-guide.md
@@ -268,14 +268,17 @@ julia> BestieTemplate.add_feature(:changelog, ".")
 
 See the [`BestieTemplate.add_feature`](@ref) docstring for the available features.
 
-The same operation is available without Julia, through the experimental `bestie-template` Python package, so it also works from a plain shell or from an AI coding agent.
-It is not on PyPI yet, so with [uv](https://docs.astral.sh/uv/) installed:
+The same operation is available without Julia, through the experimental [`bestie-template`](https://pypi.org/p/bestie-template) Python package, so it also works from a plain shell or from an AI coding agent.
+With [uv](https://docs.astral.sh/uv/) installed, no install step is needed:
 
 ```bash
-uvx --from 'git+https://github.com/JuliaBesties/BestieTemplate.jl@main#subdirectory=python' bestie list-features
+uvx --from bestie-template bestie list-features
 ```
 
 Replace `list-features` with `add-feature changelog,dependabot` to apply features, and see `bestie --help` for the options (`-d KEY=VALUE` to answer questions, `--ref` to pin a template version, `--json` for machine-readable output).
+
+For AI coding agents, this workflow is packaged as the [`bestie-features` skill](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/skills/bestie-features/SKILL.md), which teaches the agent the commands, the feature names and the follow-up work some features need.
+Install it with [`npx skills add JuliaBesties/BestieTemplate.jl`](https://www.skills.sh).
 
 ## Setting up your package
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,13 +2,15 @@
 
 Python interface to [BestieTemplate](https://github.com/JuliaBesties/BestieTemplate.jl): add template features to an existing Julia package without installing Julia.
 
-> **Status: experimental, not yet on PyPI.**
+> **Status: experimental.**
 
 With [uv](https://docs.astral.sh/uv/), no install step is needed:
 
 ```sh
-uvx --from 'git+https://github.com/JuliaBesties/BestieTemplate.jl@main#subdirectory=python' bestie list-features
+uvx --from bestie-template bestie list-features
 ```
+
+The command is `bestie`, hence the `--from`. Since 0.1.1 the package also installs `bestie-template` as an alias, so `uvx bestie-template list-features` works too.
 
 The two commands (`bestie --help` for all options):
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bestie-template"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python interface to the BestieTemplate copier template: add template features to Julia packages without Julia"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -21,9 +21,12 @@ classifiers = [
 ]
 dependencies = ["copier>=9.14,<10", "pyyaml>=6", "typer>=0.12"]
 
-# The entry point is the Typer instance itself, not a main() wrapper
+# The entry point is the Typer instance itself, not a main() wrapper.
+# `bestie-template` is an alias of `bestie` so that `uvx bestie-template` works
+# without `--from`: uvx runs the script whose name matches the package.
 [project.scripts]
 bestie = "bestie_template.cli:app"
+bestie-template = "bestie_template.cli:app"
 
 [project.urls]
 Repository = "https://github.com/JuliaBesties/BestieTemplate.jl"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "bestie-template"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },

--- a/skills/bestie-features/SKILL.md
+++ b/skills/bestie-features/SKILL.md
@@ -7,12 +7,13 @@ description: Add BestieTemplate features (AGENTS.md, changelog, dependabot, pre-
 
 `bestie add-feature` applies a named slice of the [BestieTemplate](https://github.com/JuliaBesties/BestieTemplate.jl) copier template to an existing package: only the feature's files are written, everything else is left untouched. Requires only [uv](https://docs.astral.sh/uv/) on the PATH.
 
-Until `bestie-template` is published to PyPI, `bestie` in the commands below stands for this full invocation:
+`bestie` in the commands below stands for this full invocation:
 
 ```sh
-uvx --from 'git+https://github.com/JuliaBesties/BestieTemplate.jl@main#subdirectory=python' bestie
+uvx --from bestie-template bestie
 ```
 
+(The `--from` is needed because the package is `bestie-template` and its command is `bestie`.)
 Inline the full invocation in every command — do not rely on a shell alias or variable, which won't survive when each command runs in a fresh shell.
 
 ## Workflow
@@ -48,4 +49,4 @@ Both commands accept `--json`. Failures print `{"error": "<message>"}` and exit 
 
 ## Version pinning
 
-`--ref vX.Y.Z` pins the template version; the default is the latest template release. An error saying the feature "produced none of its files" means the rendered template version predates it — pass a newer `--ref`. **Until the next template release, always pass `--ref main`** (the latest release predates several features, including `agents`).
+`--ref vX.Y.Z` pins the template version; the default is the latest template release, which is what you normally want. An error saying the feature "produced none of its files" means the rendered template version predates it — pass a newer `--ref`, or `--ref main` for a feature that has not made it into a release yet.


### PR DESCRIPTION
Add a `bestie-template` console script as an alias of `bestie`, so the
package can be run as `uvx bestie-template ...` without `--from`.

Now that `bestie-template` is on PyPI, install it from there instead of
from the git repository in the docs, the skill and `python/README.md`,
and drop the `--ref main` workaround from the skill: `features.toml` at
v0.19.0 matches `main`, so the default (latest release) is correct.

Also document the `bestie-features` skill and `npx skills add` in the
README and the full guide.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
