### PR TITLE
Parse the test runner arguments when it is included, not only when run

### DIFF
--- a/.github/workflows/ReusableTestGeneratedPkg.yml
+++ b/.github/workflows/ReusableTestGeneratedPkg.yml
@@ -125,6 +125,23 @@ jobs:
           julia --project=test -e 'using Pkg; Pkg.instantiate()'
           julia --project=test test/runtests.jl --verbose
 
+      - name: Check that test_args reach the TestItem CLI
+        if: ${{ inputs.testing_strategy == 'testitem_cli' }}
+        run: |
+          set -o pipefail
+          cd tmp/Guldasta.jl
+          # An unknown flag must be rejected. `Pkg.test` includes runtests.jl instead of
+          # executing it, and the runner used to skip argument parsing on that path, so
+          # correct and misspelled flags alike were ignored.
+          if julia --project=. --eval 'using Pkg; Pkg.test(; test_args = ["--not-a-flag"])'; then
+            echo "::error::the generated test runner ignored its test_args"
+            exit 1
+          fi
+          # A real filter must run a strict subset of the test items.
+          julia --project=. --eval 'using Pkg; Pkg.test(; test_args = ["--tags", "validation"])' 2>&1 | tee filtered.log
+          grep -q "Input validation test" filtered.log
+          ! grep -q "Performance test" filtered.log
+
         # TODO: 'lts' is assumed to be 1.10. After lts is updated, there
         # shouldn't be any need to branch below, and we can use only the second
         # version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+BREAKING NOTICE
+
+- The `testitem_cli` testing strategy option has changed slightly fixing a bug and removing an unnecessary temporary environment.
+
 ### Added
 
 - New workflow `.github/workflows/PublishPython.yml`, publishing the `bestie-template` Python package to PyPI on `py-v*` tags via trusted publishing (no tokens)
@@ -18,6 +22,11 @@ and this project adheres to [Semantic Versioning].
 - The documentation, the `bestie-features` skill and `python/README.md` now install `bestie-template` from PyPI instead of from the git repository
 - The README and the full guide now mention the `bestie-features` agent skill and how to install it with `npx skills add JuliaBesties/BestieTemplate.jl`
 - `python/pyproject.toml` now sets a one-week `exclude-newer` dependency cooldown
+- The `testitem_cli` test runner no longer builds a temporary environment to bring the package into scope. The `[sources]` section that `test/Project.toml` gained in 0.17.1 (#559) already does that, so `Pkg` is no longer a test dependency of that strategy (#640)
+
+### Fixed
+
+- The filter flags of the `testitem_cli` test runner now work when the tests are run through `Pkg.test`, which includes `test/runtests.jl` instead of executing it as a program. Filters passed as `test_args` were previously ignored, and so were misspelled flags, both without any warning. This affects `pkg> test` and `julia-actions/julia-runtest` as well (#640)
 
 ## [0.19.0] - 2026-08-02
 

--- a/template/test/Project.toml.jinja
+++ b/template/test/Project.toml.jinja
@@ -1,8 +1,5 @@
 [deps]
 {{ PackageName }} = "{{ PackageUUID }}"
-{% if TestingStrategy == 'testitem_cli' -%}
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-{% endif -%}
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 {% if TestingStrategy == 'testitem_cli' or TestingStrategy == 'testitem_basic' -%}
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"

--- a/template/test/{% if TestingStrategy == 'testitem_cli' %}runtests.jl{% endif %}.jinja
+++ b/template/test/{% if TestingStrategy == 'testitem_cli' %}runtests.jl{% endif %}.jinja
@@ -1,6 +1,5 @@
 #!/usr/bin/env julia
 
-using Pkg
 using TestItemRunner
 using TOML
 
@@ -22,6 +21,9 @@ function _print_help()
       julia --project=test test/runtests.jl --name "Some test name"       # Run specific test by name
       julia --project=test test/runtests.jl --pattern "Some pattern"      # Run test names or files that match pattern
       julia --project=test test/runtests.jl --exclude tag1,tags2          # Exclude tests with any of the tags
+
+  The same flags can be passed through `Pkg.test`:
+      julia --project=. -e 'using Pkg; Pkg.test(; test_args = ["--tags", "fast"])'
   """
   return
 end
@@ -54,7 +56,15 @@ const TAGS_DATA = Dict( # The tags below are a suggestion
   # Features (What features are being tested?)
 )
 
-function main()
+"""
+    main(; verbose_default = false)
+
+Parse `ARGS` and run the selected test items.
+
+`verbose_default` is used when neither `--verbose` nor `-v` is passed. It is set for the
+`Pkg.test` entry point, which has always shown the per-test-item breakdown.
+"""
+function main(; verbose_default = false)
   args = parse_arguments()
 
   if args.help
@@ -70,23 +80,13 @@ function main()
   println("Running Test Items")
   println("="^30)
 
+  verbose = args.verbose || verbose_default
   filter_func = _create_filter(args)
-  test_project_toml_path = joinpath(@__DIR__, "Project.toml")
 
-  mktempdir() do envdir
-    cd(envdir) do
-      # Copy test/Project.toml over to temporary folder
-      cp(test_project_toml_path, joinpath(envdir, "Project.toml"))
-      # `pkg> dev` the package
-      Pkg.activate(envdir)
-      Pkg.develop(; path = joinpath(@__DIR__, ".."))
-      # Run the tests
-      if isnothing(filter_func)
-        @run_package_tests verbose = args.verbose
-      else
-        @run_package_tests verbose = args.verbose filter = filter_func
-      end
-    end
+  if isnothing(filter_func)
+    @run_package_tests verbose = verbose
+  else
+    @run_package_tests verbose = verbose filter = filter_func
   end
 
   return
@@ -273,9 +273,11 @@ function _create_filter(args)
   return test_item -> all(f(test_item) for f in filters)
 end
 
-# Run only if this script is executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
+  # Executed as a program, e.g. `julia --project=test test/runtests.jl --tags fast`
   main()
 else
-  @run_package_tests verbose = true
+  # Included instead of executed, which is what `Pkg.test` does. It forwards its
+  # `test_args` through `ARGS`, so the filters above work from `pkg> test` as well.
+  main(; verbose_default = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,6 @@ if get(ENV, "CI", "nothing") == "nothing"
   end
 end
 
-using Pkg
 using TestItemRunner
 using TOML
 
@@ -32,6 +31,9 @@ function _print_help()
       julia --project=test test/runtests.jl --name "Some test name"       # Run specific test by name
       julia --project=test test/runtests.jl --pattern "Some pattern"      # Run test names or files that match pattern
       julia --project=test test/runtests.jl --exclude tag1,tags2          # Exclude tests with any of the tags
+
+  The same flags can be passed through `Pkg.test`:
+      julia --project=. -e 'using Pkg; Pkg.test(; test_args = ["--tags", "fast"])'
   """
   return
 end
@@ -82,7 +84,15 @@ const TAGS_DATA = Dict(
   :diagnostic => "Temporary diagnostic tests for verifying specific behaviors",
 )
 
-function main()
+"""
+    main(; verbose_default = false)
+
+Parse `ARGS` and run the selected test items.
+
+`verbose_default` is used when neither `--verbose` nor `-v` is passed. It is set for the
+`Pkg.test` entry point, which has always shown the per-test-item breakdown.
+"""
+function main(; verbose_default = false)
   args = parse_arguments()
 
   if args.help
@@ -98,23 +108,13 @@ function main()
   println("Running Test Items")
   println("="^30)
 
+  verbose = args.verbose || verbose_default
   filter_func = _create_filter(args)
-  test_project_toml_path = joinpath(@__DIR__, "Project.toml")
 
-  mktempdir() do envdir
-    cd(envdir) do
-      # Copy test/Project.toml over to temporary folder
-      cp(test_project_toml_path, joinpath(envdir, "Project.toml"))
-      # `pkg> dev` the package
-      Pkg.activate(envdir)
-      Pkg.develop(; path = joinpath(@__DIR__, ".."))
-      # Run the tests
-      if isnothing(filter_func)
-        @run_package_tests verbose = args.verbose
-      else
-        @run_package_tests verbose = args.verbose filter = filter_func
-      end
-    end
+  if isnothing(filter_func)
+    @run_package_tests verbose = verbose
+  else
+    @run_package_tests verbose = verbose filter = filter_func
   end
 
   return
@@ -300,9 +300,11 @@ function _create_filter(args)
   return test_item -> all(f(test_item) for f in filters)
 end
 
-# Run only if this script is executed directly
 if abspath(PROGRAM_FILE) == @__FILE__
+  # Executed as a program, e.g. `julia --project=test test/runtests.jl --tags fast`
   main()
 else
-  @run_package_tests verbose = true
+  # Included instead of executed, which is what `Pkg.test` does. It forwards its
+  # `test_args` through `ARGS`, so the filters above work from `pkg> test` as well.
+  main(; verbose_default = true)
 end

--- a/test/test-testing-strategy.jl
+++ b/test/test-testing-strategy.jl
@@ -6,7 +6,7 @@
   # Expected dependency matrix based on template changes
   expected_deps = Dict(
     "basic" => Set(["Test", "TOML"]),
-    "testitem_cli" => Set(["Pkg", "Test", "TestItems", "TestItemRunner", "TOML"]),
+    "testitem_cli" => Set(["Test", "TestItems", "TestItemRunner", "TOML"]),
     "testitem_basic" => Set(["Test", "TestItems", "TestItemRunner", "TOML"]),
     "basic_auto_discover" => Set(["Test", "TOML"]),
   )
@@ -103,6 +103,17 @@ end
   @test contains(runtests_content, "TAGS_DATA")
   @test contains(runtests_content, "parse_arguments")
   @test contains(runtests_content, "_print_help")
+
+  # `Pkg.test` includes the runner instead of executing it, so the branch taken when
+  # `PROGRAM_FILE` does not match must still go through `main`. Otherwise `ARGS` is never
+  # parsed and `test_args` filters are silently ignored (issue #640).
+  @test contains(runtests_content, "main(; verbose_default = true)")
+  @test !contains(runtests_content, "@run_package_tests verbose = true")
+
+  # The package is put in scope by the `[sources]` section of test/Project.toml, so the
+  # runner must not build a temporary environment of its own (issue #640).
+  @test !contains(runtests_content, "mktempdir")
+  @test !contains(runtests_content, "Pkg.develop")
 
   # Should not have additional test files (CLI handles everything)
   @test has_test_file


### PR DESCRIPTION
`Pkg.test` includes test/runtests.jl instead of executing it as a program, so
`abspath(PROGRAM_FILE) == @__FILE__` was false and the testitem_cli runner never
parsed ARGS. Filters passed as test_args were ignored, and so were misspelled
flags, both without any warning. Both branches now go through `main`, and the
include path defaults to verbose so that CI output stays the same.

Also drop the temporary environment that the runner built to bring the package
into scope. The [sources] section that test/Project.toml gained in 0.17.1 does
that already, so Pkg is no longer a test dependency of that strategy.

Closes #640

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
