### PR TITLE
Add the lint_action_explicit feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ requires_answers = false                      # true = .copier-answers.yml must 
 
 Aliases are their own entry with a single key: `alias_of = "my_feature"`. Do not edit the feature list in the `add_feature` docstring — it is generated from the TOML at load time (`_features_docstring` in `src/friendly.jl`).
 
-Data merge order (later wins): answers file → guessed from repo → explicit `data` arg → `forced_data`.
+Data merge order (later wins): answers file → guessed from repo → explicit `data` arg → `forced_data`. Guessing (`src/guess.jl`) only covers facts readable off the package — `PackageName`, `PackageUUID`, `Authors`, `JuliaMinVersion`, `PackageOwner`, `JuliaIndentation` — so `required_fields` outside that set must come from the answers file or the caller. The Python port does not guess at all.
+
+`requires_answers = true` is for features whose `required_fields` fall outside what guessing covers, where a default would silently render a wrong file (`lint_action`: `AddPrecommit` and `AddLychee` say which tools the package uses, `Lint.yml` runs a job for each, and guessing doesn't cover them — the Python CLI never guesses at all). When that set of fields is small and closed, also add a `<feature>_explicit` entry that lists them in `required_fields` with `requires_answers = false`, so packages without `.copier-answers.yml` can use the feature by stating its intent. Skip the variant when the output depends on many answers. See the developer docs for the full rationale.
 
 Before writing tests, verify the entry matches the template: the `included_files` are gated on the `forced_data` flag (e.g. `{% if MyFlag %}filename{% endif %}.jinja`), and the `required_fields` really are required. Ask the user if anything is ambiguous.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BREAKING NOTICE
 
 ### Added
 
+- New feature `add_feature(:lint_action_explicit)`, which adds `.github/workflows/Lint.yml` to any package by taking the answers that say which tools the package uses (`AddPrecommit`, `AddLychee`) as explicit data, instead of requiring an existing `.copier-answers.yml` like `:lint_action`
 - New workflow `.github/workflows/PublishPython.yml`, publishing the `bestie-template` Python package to PyPI on `py-v*` tags via trusted publishing (no tokens)
 
 ### Changed

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -148,9 +148,33 @@ Aliases are entries with a single `alias_of = "other_feature"` key.
 
 **Data merge order** (later wins): answers file → guessed from repo → explicit `data` arg → `forced_data`.
 
+If the `required_fields` can be guessed (e.g., by `_read_data_from_existing_path` in `src/guess.jl`, or if they are present in a `.copier-answers.yml` file), then the experience is smooth.
+Otherwise, they need to be given explicitly, e.g., via the `data` argument in Julia, or `-d` flags in the Python CLI.
+
+#### [When a feature depends on user choices: the `_explicit` convention](@id explicit_features)
+
+`requires_answers = true` was introduced to deal with features that could not be guessed from a repo.
+Essentially, these are features that require more than the minimum information in an existing package.
+`lint_action` is one case: `AddPrecommit` and `AddLychee` record whether the package uses pre-commit and the Lychee link checker (`copier/code-quality.yml`), and `Lint.yml` runs a job for each tool that is enabled.
+These answers are not automatically guessed from the package - even if they could be in the future - and via the Python CLI they can't be guessed.
+If forcing the template defaults, these answers would give a wrong result. In this case, for example, the `Lint.yml` action would be created but it would be essentially empty, becoming useless.
+The flag prevents that by insisting the package already recorded its answers.
+
+That is the right guard, but it locks the feature to packages that already use the template. When the set of choices is small and closed, we should try to ship a second entry named `<feature>_explicit` that lists these answers in `required_fields` with `requires_answers = false`:
+
+```toml
+[features.lint_action_explicit]
+required_fields = ["AddPrecommit", "AddLychee"]
+requires_answers = false
+```
+
+Any package can then use it by stating its intent (`-d AddPrecommit=true -d AddLychee=false`), and the "cannot determine required fields" error names exactly what to pass. Packages that *do* have an answers file keep working, since the fields resolve from it.
+
+Add the `_explicit` variant when the dependency set is small, enumerable, and meaningful to a user. Keep `requires_answers = true` alone when the output depends on many answers, or on ones a user cannot reasonably be asked to supply — an explicit variant that needs ten flags is worse than no variant.
+
 **Checklist to add a new feature:**
 
-1. Add a `[features.my_feature]` entry in `features.toml`.
+1. Add a `[features.my_feature]` entry in `features.toml`. If it needs `requires_answers = true`, decide whether an `_explicit` companion is warranted (see [the `_explicit` convention](@ref explicit_features)).
 2. Check that the entry matches the template: the `included_files` in `template/` should be gated on the `forced_data` flag (e.g. `{% if MyFlag %}filename{% endif %}.jinja`), and the `required_fields` should be ones the feature genuinely cannot resolve on its own.
 3. Add tests in `test/test-add-feature.jl` using the `AddFeatureHelpers` snippet helpers (defined in the same file):
    - `_test_happy_path`: feature generates expected file(s)

--- a/features.toml
+++ b/features.toml
@@ -2,12 +2,22 @@
 # Julia package and future non-Julia interfaces (see docs/src/91-developer.md).
 #
 # Field semantics:
-# - description: one line, user-facing; the `add_feature` docstring list is generated from it
+# - description: one line, user-facing; the `add_feature` docstring list is generated from it.
+#   When a `required_fields` entry is not guessable (see below), say in the description how a
+#   caller can tell what the value should be — usually a file whose presence implies it. This is
+#   the only place that information reaches a user or an agent choosing the flags.
 # - forced_data: answers always applied, highest priority in the data merge order
 # - included_files: the only paths copier writes (everything else is excluded);
 #   must be gated in the template on the forced_data flag(s)
-# - required_fields: answer keys that must be resolvable or the operation errors
-# - requires_answers: true = `.copier-answers.yml` must exist in the destination
+# - required_fields: answer keys that must be resolvable or the operation errors.
+#   Resolution order is guessed data (Julia only, see `_read_data_from_existing_path` in
+#   `src/guess.jl`) -> `.copier-answers.yml` -> the caller's `data`/`-d` flags. Guessing only
+#   covers facts readable off the package: PackageName, PackageUUID, Authors, JuliaMinVersion,
+#   PackageOwner, JuliaIndentation. Anything else has to be stated by the caller.
+# - requires_answers: true = `.copier-answers.yml` must exist in the destination. Use this only
+#   when a `required_fields` entry falls outside what guessing covers (limited to the facts
+#   listed above; the Python CLI never guesses at all) and no sane default exists. See the
+#   `_explicit` convention in docs/src/91-developer.md before adding one.
 # - alias_of: this feature is an alias of another entry (no other fields allowed)
 
 schema_version = 1
@@ -34,11 +44,18 @@ required_fields = ["PackageName"]
 requires_answers = false
 
 [features.lint_action]
-description = "Adds the `.github/workflows/Lint.yml` GitHub Actions workflow"
+description = "Adds the `.github/workflows/Lint.yml` GitHub Actions workflow, reusing the package's recorded answers to decide which tools it runs (requires `.copier-answers.yml`)"
 forced_data = { AddLintCI = true }
 included_files = [".github/workflows/Lint.yml"]
 required_fields = []
 requires_answers = true
+
+[features.lint_action_explicit]
+description = "Adds the `.github/workflows/Lint.yml` GitHub Actions workflow to any package, taking as explicit data the answers that say which tools the package uses: `AddPrecommit` (pre-commit) and `AddLychee` (the Lychee link checker). The workflow runs one job per enabled tool, so at least one answer must be true or it renders with no jobs. An existing config file (`.pre-commit-config.yaml`, `.lychee.toml`) means the package already uses that tool and the answer is true; no config file means only that it does not use it yet, so ask before deciding"
+forced_data = { AddLintCI = true }
+included_files = [".github/workflows/Lint.yml"]
+required_fields = ["AddPrecommit", "AddLychee"]
+requires_answers = false
 
 [features.pre_commit]
 alias_of = "pre_commit_with_config"

--- a/python/tests/test_features.py
+++ b/python/tests/test_features.py
@@ -19,6 +19,7 @@ class TestRegistry:
             "changelog",
             "dependabot",
             "lint_action",
+            "lint_action_explicit",
             "pre_commit",
             "pre_commit_with_config",
             "pre_commit_without_config",

--- a/test/test-add-feature.jl
+++ b/test/test-add-feature.jl
@@ -279,6 +279,45 @@ end
   _test_errors_without_data(:lint_action)
 end
 
+@testitem "add_feature(:lint_action_explicit) generates Lint.yml from explicit tool answers" tags =
+  [:integration, :slow, :template_application, :file_io, :python_integration] setup =
+  [Common, AddFeatureHelpers] begin
+  _test_works_on_empty_folder(
+    :lint_action_explicit,
+    joinpath(".github", "workflows", "Lint.yml"),
+    data = Dict("AddPrecommit" => true, "AddLychee" => false),
+    # The `lint:` job's display name, which exists only when the job does
+    expected_content = "name: Linting",
+  )
+end
+
+@testitem "add_feature(:lint_action_explicit) the tool answers select the jobs" tags =
+  [:integration, :slow, :template_application, :file_io] setup = [Common, AddFeatureHelpers] begin
+  lint_yml = joinpath(".github", "workflows", "Lint.yml")
+  # The answers are user choices, never guessable, so each must reach the rendered workflow.
+  # Assert on each job's own key or display name, not on the tool names its steps mention.
+  _test_explicit_data_override(
+    :lint_action_explicit,
+    Dict("AddPrecommit" => false, "AddLychee" => true),
+    lint_yml,
+    "link-checker",
+    unexpected = "name: Linting",
+  )
+  _test_explicit_data_override(
+    :lint_action_explicit,
+    Dict("AddPrecommit" => true, "AddLychee" => false),
+    lint_yml,
+    "name: Linting",
+    unexpected = "link-checker",
+  )
+end
+
+@testitem "add_feature(:lint_action_explicit) errors without the tool answers" tags =
+  [:unit, :fast, :error_handling] setup = [Common, AddFeatureHelpers] begin
+  # Unlike :lint_action it needs no answers file, but the two flags have no guessable source
+  _test_errors_without_data(:lint_action_explicit)
+end
+
 @testitem "add_feature(:dependabot) generates dependabot.yml" tags =
   [:integration, :slow, :template_application, :file_io, :python_integration] setup =
   [Common, AddFeatureHelpers] begin


### PR DESCRIPTION
`add_feature(:lint_action)` refuses to run without `.copier-answers.yml`,
which locks it to packages that already applied the full template. The guard
is correct — `Lint.yml` renders from `AddPrecommit` and `AddLychee`, which
record whether the package uses pre-commit and the Lychee link checker, and
neither can be read off the package. With template defaults you get a
workflow that checks the wrong things, or nothing at all, reported as success.

Since that set of answers is small and closed, add a second entry that takes
them as `required_fields` with `requires_answers = false`, so any package can
use the feature by stating its intent. Packages that do have an answers file
are unaffected: the fields resolve from it as before.

Document the convention behind the `_explicit` suffix, and record what
`src/guess.jl` actually guesses — only facts readable off the package — since
that is what decides whether a field can be a `required_field` at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
