### PR TITLE
Add optional_files to the feature registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Each feature is defined by an entry in `features.toml` at the repo root (single 
 description = "Adds `path/to/output/file.ext` ..."  # user-facing; the add_feature docstring list is generated from it
 forced_data = { MyFlag = true }               # always applied, highest priority
 included_files = ["path/to/output/file.ext"]  # only these files are written by copier
+optional_files = { SomeFlag = ["config.toml"] }  # optional; written only when SomeFlag and missing
 required_fields = ["RequiredField"]           # must be resolvable or errors
 requires_answers = false                      # true = .copier-answers.yml must exist
 ```
@@ -68,6 +69,8 @@ Aliases are their own entry with a single key: `alias_of = "my_feature"`. Do not
 Data merge order (later wins): answers file → guessed from repo → explicit `data` arg → `forced_data`. Guessing (`src/guess.jl`) only covers facts readable off the package — `PackageName`, `PackageUUID`, `Authors`, `JuliaMinVersion`, `PackageOwner`, `JuliaIndentation` — so `required_fields` outside that set must come from the answers file or the caller. The Python port does not guess at all.
 
 `requires_answers = true` is for features whose `required_fields` fall outside what guessing covers, where a default would silently render a wrong file (`lint_action`: `AddPrecommit` and `AddLychee` say which tools the package uses, `Lint.yml` runs a job for each, and guessing doesn't cover them — the Python CLI never guesses at all). When that set of fields is small and closed, also add a `<feature>_explicit` entry that lists them in `required_fields` with `requires_answers = false`, so packages without `.copier-answers.yml` can use the feature by stating its intent. Skip the variant when the output depends on many answers. See the developer docs for the full rationale.
+
+`optional_files` maps a boolean field to files the feature's own output needs when that field is true (`lint_action_explicit`'s `link-checker` job reads `.lychee.toml`). They are written only when missing, so an existing file is kept and two features may declare the same path without conflict. Declare what your output references, not what you "own". Test the flags with `_is_true`, never directly: a CLI `-d Flag=false` arrives as the string `"false"`, which is truthy in both languages.
 
 Before writing tests, verify the entry matches the template: the `included_files` are gated on the `forced_data` flag (e.g. `{% if MyFlag %}filename{% endif %}.jinja`), and the `required_fields` really are required. Ask the user if anything is ambiguous.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BREAKING NOTICE
 ### Added
 
 - New feature `add_feature(:lint_action_explicit)`, which adds `.github/workflows/Lint.yml` to any package by taking the answers that say which tools the package uses (`AddPrecommit`, `AddLychee`) as explicit data, instead of requiring an existing `.copier-answers.yml` like `:lint_action`
+- New optional `optional_files` field in `features.toml`, mapping a boolean answer to files the feature's output needs when it is true — `:lint_action_explicit` uses it for `.lychee.toml` and `.pre-commit-config.yaml`, which its jobs read. They are written only when missing, so an existing file is kept and two features can declare the same path
 - New workflow `.github/workflows/PublishPython.yml`, publishing the `bestie-template` Python package to PyPI on `py-v*` tags via trusted publishing (no tokens)
 
 ### Changed

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -140,11 +140,23 @@ For questions with non-trivial types, add a `_random(::Val{:QuestionName}, value
 description = "Adds `path/to/output/file.ext` ..."  # user-facing; the add_feature docstring list is generated from it
 forced_data = { MyFlag = true }               # always applied, highest priority
 included_files = ["path/to/output/file.ext"]  # only these files are written by copier
+optional_files = { SomeFlag = ["config.toml"] }  # optional; written only if missing, see below
 required_fields = ["RequiredField"]           # must be resolvable or errors
 requires_answers = false                      # true = .copier-answers.yml must exist
 ```
 
 Aliases are entries with a single `alias_of = "other_feature"` key.
+
+#### Optional files
+
+`included_files` are always written. `optional_files` covers a different case: a file the feature's *own output* needs only when a boolean answer is true. `lint_action_explicit` is the example — its `link-checker` job runs lychee with `--config '.lychee.toml'`, so enabling the job without shipping that config produces a workflow that cannot run.
+
+Two rules make this safe:
+
+- **Written only if missing.** A `.lychee.toml` the user has tuned is never overwritten, and the feature stays additive.
+- **Declare what your output references, not what you "own".** Two features may list the same path; whichever runs first writes it, the other finds it there and does nothing. This is deliberate: it means adding a future `lychee` feature that also writes `.lychee.toml` does not break `lint_action_explicit`.
+
+Keys must be boolean fields the caller can set — `required_fields` or `forced_data` entries. Beware that a flag passed on the CLI arrives as the *string* `"false"`, which is truthy in both languages; copier only coerces it at render time. Test these with `_is_true` (`src/friendly.jl`, `python/src/bestie_template/__init__.py`), never directly.
 
 **Data merge order** (later wins): answers file → guessed from repo → explicit `data` arg → `forced_data`.
 
@@ -175,7 +187,7 @@ Add the `_explicit` variant when the dependency set is small, enumerable, and me
 **Checklist to add a new feature:**
 
 1. Add a `[features.my_feature]` entry in `features.toml`. If it needs `requires_answers = true`, decide whether an `_explicit` companion is warranted (see [the `_explicit` convention](@ref explicit_features)).
-2. Check that the entry matches the template: the `included_files` in `template/` should be gated on the `forced_data` flag (e.g. `{% if MyFlag %}filename{% endif %}.jinja`), and the `required_fields` should be ones the feature genuinely cannot resolve on its own.
+2. Check that the entry matches the template: the `included_files` in `template/` should be gated on the `forced_data` flag (e.g. `{% if MyFlag %}filename{% endif %}.jinja`), and the `required_fields` should be ones the feature genuinely cannot resolve on its own. Read the rendered output for files it references but does not write — those belong in `optional_files`.
 3. Add tests in `test/test-add-feature.jl` using the `AddFeatureHelpers` snippet helpers (defined in the same file):
    - `_test_happy_path`: feature generates expected file(s)
    - `_test_works_without_answers_by_guessing` (if `requires_answers = false`): works when data is guessable

--- a/features.toml
+++ b/features.toml
@@ -8,7 +8,15 @@
 #   the only place that information reaches a user or an agent choosing the flags.
 # - forced_data: answers always applied, highest priority in the data merge order
 # - included_files: the only paths copier writes (everything else is excluded);
-#   must be gated in the template on the forced_data flag(s)
+#   must be gated in the template on the forced_data flag(s). Always overwritten.
+# - optional_files: optional; maps a boolean field to files that the feature's own output needs
+#   when that field is true (e.g. the `link-checker` job reads `.lychee.toml`). Each is written
+#   only if it does not already exist, so a file the user has tuned is never overwritten and two
+#   features may safely declare the same path — whichever runs first writes it. Declare a file
+#   here only if this feature's rendered output references it; do not consider which other
+#   feature "owns" it. Non-boolean fields are not supported. Keys must be fields the caller can
+#   set — a required_fields or forced_data entry — so the file follows from a stated intent
+#   rather than reappearing after a user deleted it on purpose.
 # - required_fields: answer keys that must be resolvable or the operation errors.
 #   Resolution order is guessed data (Julia only, see `_read_data_from_existing_path` in
 #   `src/guess.jl`) -> `.copier-answers.yml` -> the caller's `data`/`-d` flags. Guessing only
@@ -51,9 +59,10 @@ required_fields = []
 requires_answers = true
 
 [features.lint_action_explicit]
-description = "Adds the `.github/workflows/Lint.yml` GitHub Actions workflow to any package, taking as explicit data the answers that say which tools the package uses: `AddPrecommit` (pre-commit) and `AddLychee` (the Lychee link checker). The workflow runs one job per enabled tool, so at least one answer must be true or it renders with no jobs. An existing config file (`.pre-commit-config.yaml`, `.lychee.toml`) means the package already uses that tool and the answer is true; no config file means only that it does not use it yet, so ask before deciding"
+description = "Adds the `.github/workflows/Lint.yml` GitHub Actions workflow to any package, taking as explicit data the answers that say which tools the package uses: `AddPrecommit` (pre-commit) and `AddLychee` (the Lychee link checker). The workflow runs one job per enabled tool, so at least one answer must be true or it renders with no jobs. Each enabled tool's config file (`.pre-commit-config.yaml`, `.lychee.toml`) is created only if missing, so an existing one is kept as is. An existing config file means the package already uses that tool and the answer is true; no config file means only that it does not use it yet, so ask before deciding"
 forced_data = { AddLintCI = true }
 included_files = [".github/workflows/Lint.yml"]
+optional_files = { AddPrecommit = [".pre-commit-config.yaml"], AddLychee = [".lychee.toml"] }
 required_fields = ["AddPrecommit", "AddLychee"]
 requires_answers = false
 

--- a/python/src/bestie_template/__init__.py
+++ b/python/src/bestie_template/__init__.py
@@ -112,6 +112,11 @@ def add_feature(
         for field in PLACEHOLDER_FIELDS:
             merged.setdefault(field, PLACEHOLDER_VALUE)
         included = list(spec["included_files"])
+        # Files the feature's output needs when a flag is on, added only when missing so a
+        # config the user already tuned survives (see optional_files in features.toml).
+        for field, files in spec.get("optional_files", {}).items():
+            if _is_true(merged.get(field)):
+                included += [file for file in files if not (dst / file).exists()]
         exclude = ["**", *(f"!{file}" for file in included)]
         if has_answers:
             exclude.append(f"!{ANSWERS_FILENAME}")
@@ -127,9 +132,10 @@ def add_feature(
             vcs_ref=ref,
         )
 
-        if not any((dst / file).exists() for file in included):
+        required_files = spec["included_files"]
+        if not any((dst / file).exists() for file in required_files):
             raise BestieError(
-                f"Feature {name!r} produced none of its files ({', '.join(included)}). The "
+                f"Feature {name!r} produced none of its files ({', '.join(required_files)}). The "
                 f"rendered template ref ({ref or 'the latest release'}) probably predates this "
                 "feature; pass a ref of a template version that includes it."
             )
@@ -140,6 +146,17 @@ def add_feature(
         applied.append({"name": name, "files": included})
 
     return {"dst": str(dst), "applied": applied, "answers_file_updated": has_answers}
+
+
+def _is_true(value: Any) -> bool:
+    """Whether an answer means boolean true.
+
+    Values reaching us from `-d FLAG=false` are the *string* `"false"`, which is truthy in
+    Python; copier only coerces them at render time. So never test these flags directly.
+    """
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return value is True
 
 
 def _resolve(registry: dict[str, dict[str, Any]], name: str) -> dict[str, Any]:

--- a/python/tests/test_features.py
+++ b/python/tests/test_features.py
@@ -31,13 +31,25 @@ class TestRegistry:
             if "alias_of" in spec:
                 assert set(spec) == {"alias_of"}, name
                 continue
-            assert set(spec) == {
+            assert set(spec) <= {
+                "description",
+                "forced_data",
+                "included_files",
+                "optional_files",
+                "required_fields",
+                "requires_answers",
+            }, name
+            assert set(spec) >= {
                 "description",
                 "forced_data",
                 "included_files",
                 "required_fields",
                 "requires_answers",
             }, name
+            for field, files in spec.get("optional_files", {}).items():
+                # Keyed on boolean fields only, and the caller must be able to set them
+                assert field in spec["required_fields"] or field in spec["forced_data"], name
+                assert files and all(isinstance(file, str) for file in files), name
             assert spec["description"] and spec["included_files"]
 
     def test_aliases_resolve(self, registry):
@@ -154,6 +166,43 @@ class TestAgainstTheRealTemplate:
         assert "FakePkg" in content and "Pkg.test()" in content
         assert not (tmp_path / ".copier-answers.yml").exists()
         assert result["applied"] == [{"name": "agents", "files": ["AGENTS.md"]}]
+
+    def test_optional_files_are_written_when_the_flag_is_on(self, tmp_path, template):
+        add_feature(
+            ["lint_action_explicit"],
+            tmp_path,
+            {"AddPrecommit": False, "AddLychee": True},
+            template=template,
+            ref="HEAD",
+        )
+        workflow = (tmp_path / ".github/workflows/Lint.yml").read_text()
+        assert "link-checker" in workflow
+        # The job runs lychee with --config '.lychee.toml', so the config must be there too
+        assert (tmp_path / ".lychee.toml").is_file()
+        assert not (tmp_path / ".pre-commit-config.yaml").exists()
+
+    def test_optional_files_are_skipped_for_a_false_string_flag(self, tmp_path, template):
+        # "false" arrives as a truthy string from -d; only copier coerces it, and only later
+        add_feature(
+            ["lint_action_explicit"],
+            tmp_path,
+            {"AddPrecommit": "true", "AddLychee": "false"},
+            template=template,
+            ref="HEAD",
+        )
+        assert not (tmp_path / ".lychee.toml").exists()
+        assert (tmp_path / ".pre-commit-config.yaml").is_file()
+
+    def test_an_existing_optional_file_is_never_overwritten(self, tmp_path, template):
+        (tmp_path / ".lychee.toml").write_text("# tuned by hand\n")
+        add_feature(
+            ["lint_action_explicit"],
+            tmp_path,
+            {"AddPrecommit": False, "AddLychee": True},
+            template=template,
+            ref="HEAD",
+        )
+        assert (tmp_path / ".lychee.toml").read_text() == "# tuned by hand\n"
 
     def test_only_the_features_files_are_written(self, tmp_path, template):
         add_feature(

--- a/skills/bestie-features/SKILL.md
+++ b/skills/bestie-features/SKILL.md
@@ -24,9 +24,9 @@ Inline the full invocation in every command — do not rely on a shell alias or 
    bestie list-features --json
    ```
 
-   Each entry has `name`, `description`, `required_fields` (answers you must be able to supply), and `requires_answers` (needs an existing `.copier-answers.yml`). Feature names are exact (e.g. the testitem runner is `testitem_cli`, not `testitem`); if you pass a name that doesn't exist, the error lists every valid name.
+   Each entry has `name`, `description`, `required_fields` (answers you must be able to supply), `requires_answers` (needs an existing `.copier-answers.yml`), and optionally `optional_files` (extra config files written only if missing, keyed by the boolean answer that enables them). Feature names are exact (e.g. the testitem runner is `testitem_cli`, not `testitem`); if you pass a name that doesn't exist, the error lists every valid name.
 
-2. **Check the working tree before applying.** A feature overwrites the files it owns without warning, no conflict prompt and no backup — `testitem_cli` replaces an existing `test/runtests.jl` outright, discarding whatever was there. Git is the only recovery path, so run `git status` first:
+2. **Check the working tree before applying.** A feature overwrites its `included_files` without warning, no conflict prompt and no backup — `testitem_cli` replaces an existing `test/runtests.jl` outright, discarding whatever was there. `optional_files` are the opposite: written only if missing, so an existing one (e.g. a hand-tuned `.lychee.toml`) is left untouched. Git is the only recovery path for `included_files`, so run `git status` first:
 
    - Uncommitted changes to any of the feature's `included_files`: stop and tell the user those changes will be lost. Let them commit or stash before you continue.
    - A file the feature owns exists and is committed: say so and what will replace it, and get the user's go-ahead before applying.
@@ -38,7 +38,7 @@ Inline the full invocation in every command — do not rely on a shell alias or 
    bestie add-feature changelog,dependabot [PATH]
    ```
 
-4. **Verify** with `git status` / `git diff`: only the features' files should appear, plus `.copier-answers.yml` if the package already had one. Read the diff of every pre-existing file the feature touched — "Applied 1 feature(s)" is printed just the same whether the file was created or overwritten, so success output is not evidence that nothing was lost.
+4. **Verify** with `git status` / `git diff`: only the feature's `included_files` should appear as modified, any missing `optional_files` as newly added, plus `.copier-answers.yml` if the package already had one. Read the diff of every pre-existing file the feature touched — "Applied 1 feature(s)" is printed just the same whether the file was created or overwritten, so success output is not evidence that nothing was lost.
 
 A clean diff means the feature applied, not that the package is done: a feature may require follow-up changes to files it does not own (e.g. `testitem_cli` replaces the test runner, so existing tests must be migrated to `@testitem` blocks and a `test/Project.toml` must exist). Check the feature's `description` and the rendered files for such expectations, and tell the user about any follow-up work you find.
 

--- a/src/friendly.jl
+++ b/src/friendly.jl
@@ -152,6 +152,16 @@ function _load_features(registry_path::AbstractString = BUNDLED_FEATURES_TOML)
 end
 
 """
+    _is_true(value)
+
+Whether an answer means boolean `true`. Values passed through the CLI arrive as the string
+`"false"`, which copier only coerces at render time, so these flags must never be tested
+directly for truthiness.
+"""
+_is_true(value) = value === true
+_is_true(value::AbstractString) = lowercase(strip(value)) == "true"
+
+"""
     _feature_spec(features, feature::Symbol)
 
 Look up `feature` in the registry loaded by [`_load_features`](@ref), resolving aliases.
@@ -295,8 +305,18 @@ function add_feature(
 
   # Only update .copier-answers.yml when it already exists;
   # don't create it for packages not managed by BestieTemplate.
+  # Files the feature's output needs when a flag is on, added only when missing so a config
+  # the user already tuned survives (see optional_files in features.toml).
+  written_files = copy(included_files)
+  for (field, files) in get(spec, "optional_files", Dict{String, Any}())
+    _is_true(get(merged_data, field, false)) || continue
+    for f in files
+      isfile(joinpath(dst_path, f)) || push!(written_files, f)
+    end
+  end
+
   excluded = ["**"]
-  for f in included_files
+  for f in written_files
     push!(excluded, "!$f")
   end
   if has_answers

--- a/test/test-add-feature.jl
+++ b/test/test-add-feature.jl
@@ -318,6 +318,38 @@ end
   _test_errors_without_data(:lint_action_explicit)
 end
 
+@testitem "add_feature(:lint_action_explicit) writes the config files of the enabled tools" tags =
+  [:integration, :slow, :template_application, :file_io] setup = [Common, AddFeatureHelpers] begin
+  _with_tmp_dir() do _
+    _add_feature_local(:lint_action_explicit, Dict("AddPrecommit" => false, "AddLychee" => true))
+    # The link-checker job runs lychee with --config '.lychee.toml'
+    @test isfile(".lychee.toml")
+    @test !isfile(".pre-commit-config.yaml")
+  end
+end
+
+@testitem "add_feature(:lint_action_explicit) skips optional files for a \"false\" string answer" tags =
+  [:integration, :slow, :template_application, :file_io] setup = [Common, AddFeatureHelpers] begin
+  _with_tmp_dir() do _
+    # Strings are what the CLI passes; copier only coerces them at render time
+    _add_feature_local(
+      :lint_action_explicit,
+      Dict("AddPrecommit" => "true", "AddLychee" => "false"),
+    )
+    @test !isfile(".lychee.toml")
+    @test isfile(".pre-commit-config.yaml")
+  end
+end
+
+@testitem "add_feature(:lint_action_explicit) keeps an existing optional file" tags =
+  [:integration, :slow, :template_application, :file_io] setup = [Common, AddFeatureHelpers] begin
+  _with_tmp_dir() do _
+    write(".lychee.toml", "# tuned by hand\n")
+    _add_feature_local(:lint_action_explicit, Dict("AddPrecommit" => false, "AddLychee" => true))
+    @test read(".lychee.toml", String) == "# tuned by hand\n"
+  end
+end
+
 @testitem "add_feature(:dependabot) generates dependabot.yml" tags =
   [:integration, :slow, :template_application, :file_io, :python_integration] setup =
   [Common, AddFeatureHelpers] begin


### PR DESCRIPTION
A feature writes only its `included_files`, so `lint_action_explicit` emitted
a `Lint.yml` whose link-checker job runs lychee with `--config '.lychee.toml'`
while never writing that config. The workflow applied cleanly and could not run.

Add an optional `optional_files` field mapping a boolean answer to the files
the feature's own output needs when it is true. Two rules keep it safe: files
are written only when missing, so a config the user tuned survives and the
feature stays additive; and a feature declares what its output references
rather than what it "owns", so a future `lychee` feature declaring the same
path is not a breaking change.

Both implementations read the registry, so both gain the field. Flags are
tested through `_is_true`, because a `-d Flag=false` arrives as the string
"false" — truthy in Python and not a Bool in Julia — and copier only coerces
it at render time.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
