### PR TITLE
Mention the bestie-features agent skill in AGENTS.md and dev docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Julia wrapper around the Python [Copier](https://copier.readthedocs.io) template
 
 **Python package (`python/`)** — `bestie-template`, a port of `add_feature`/`list_features` that needs no Julia (experimental; published to PyPI as `bestie-template`, see issue #617). It reads the same repo-root `features.toml`, so a new feature needs no Python code — only the name added to `test_feature_names` in `python/tests/test_features.py`, which pins the feature set as a drift guard.
 
+**Agent skill (`skills/bestie-features/SKILL.md`)** — teaches an AI coding agent the `bestie` CLI workflow (list/add features, resolve answers, protected files). It documents behavior, not the feature list, so it doesn't need updating for every new `features.toml` entry — only when the CLI's workflow, answer-resolution rules, or protected-files semantics change.
+
 - Conditional file/dir inclusion via the filename: `{% if Condition %}filename{% endif %}.jinja`
 - Variable substitution in content: `{{ VariableName }}`
 

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -213,6 +213,12 @@ Both implementations read the same repo-root `features.toml`, so a new feature s
 
 Linting and formatting come from the repository-wide pre-commit setup (`ruff`, `ruff-format`; configured in `python/pyproject.toml`), and `.github/workflows/TestPython.yml` runs the suite and builds the wheel on CI.
 
+### [The agent skill (`skills/bestie-features/SKILL.md`)](@id bestie_features_skill)
+
+`skills/bestie-features/SKILL.md` teaches an AI coding agent to drive the `bestie` CLI: discovering features, checking the working tree before applying, resolving `Add*`-style answers, and the protected-files/`optional_files` rules. It's referenced from the [full guide](@ref full_guide) and installable with `npx skills add JuliaBesties/BestieTemplate.jl`.
+
+It documents *behavior*, not the feature list, so it does not need a change for every new `features.toml` entry. Update it when the CLI's workflow changes: new/renamed subcommands or flags, a change to how answers are resolved or protected files are decided, or a new `_explicit`-style convention (see [the `_explicit` convention](@ref explicit_features)) worth teaching the agent.
+
 ### Testing local changes to the template
 
 We have created tools to help test and debug changes to the template.


### PR DESCRIPTION
The skill (skills/bestie-features/SKILL.md) was referenced from the
full guide but not discoverable from AGENTS.md or the developer docs,
so a contributor changing the add_feature workflow had no pointer to
it or guidance on when it needs updating.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
