### PR TITLE
Restrict this repo's own CI tag triggers to Julia release tags

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -8,7 +8,7 @@ on:
       - "docs/**"
       - "src/**"
       - "*.toml"
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
     branches:
       - main

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["v*"]
   pull_request:
 
 concurrency:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["v*"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/TestGeneratedPkg.yml
+++ b/.github/workflows/TestGeneratedPkg.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ["*"]
+    tags: ["v*"]
 
   pull_request:
     branches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Julia wrapper around the Python [Copier](https://copier.readthedocs.io) template
 
 **Template (`template/`)** — Jinja2 files for generated packages.
 
+This repo also applies its own template to itself (see `.copier-answers.yml`), so files like `.github/workflows/*.yml` exist both as generated output here and as `template/.../*.yml.jinja` source. Before editing a generated file, check whether the fix belongs in the template (should apply to every package the template generates) or is specific to this repo's own infrastructure (e.g. dogfooding quirks, this repo's own release process). Edit the template source for the former; edit the generated file directly for the latter. If unsure which one applies, ask.
+
 **Python package (`python/`)** — `bestie-template`, a port of `add_feature`/`list_features` that needs no Julia (experimental; published to PyPI as `bestie-template`, see issue #617). It reads the same repo-root `features.toml`, so a new feature needs no Python code — only the name added to `test_feature_names` in `python/tests/test_features.py`, which pins the feature set as a drift guard.
 
 - Conditional file/dir inclusion via the filename: `{% if Condition %}filename{% endif %}.jinja`


### PR DESCRIPTION
py-v* Python release tags were also matching the tags: ["*"] filter,
rerunning Test/Lint/Docs/TestGeneratedPkg unnecessarily. (#636)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSn33ERVFeifoT1qbA3Hu6
