### PR TITLE
Add AddVSCodeRecommendations question for .vscode/extensions.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ BREAKING NOTICE
 - New feature `add_feature(:lint_action_explicit)`, which adds `.github/workflows/Lint.yml` to any package by taking the answers that say which tools the package uses (`AddPrecommit`, `AddLychee`) as explicit data, instead of requiring an existing `.copier-answers.yml` like `:lint_action`
 - New optional `optional_files` field in `features.toml`, mapping a boolean answer to files the feature's output needs when it is true — `:lint_action_explicit` uses it for `.lychee.toml` and `.pre-commit-config.yaml`, which its jobs read. They are written only when missing, so an existing file is kept and two features can declare the same path
 - New workflow `.github/workflows/PublishPython.yml`, publishing the `bestie-template` Python package to PyPI on `py-v*` tags via trusted publishing (no tokens)
+- New question `AddVSCodeRecommendations` (Advanced strategy), adding a `.vscode/extensions.json` file that recommends the Julia VS Code extension. Also available as `add_feature(:vscode_recommendations)` (#298)
 
 ### Changed
 

--- a/copier.yml
+++ b/copier.yml
@@ -28,6 +28,7 @@ _skip_if_exists:
   - CITATION.cff
   - LICENSE
   - AGENTS.md
+  - .vscode/extensions.json
 
 _subdirectory: template
 

--- a/copier/community.yml
+++ b/copier/community.yml
@@ -108,3 +108,13 @@ AddAgentsMd:
     The generated file is a minimal starting point that describes the package, how to run the tests, and a few basic conventions; you are expected to expand it as the project grows.
 
     Strategy: Advanced
+
+AddVSCodeRecommendations:
+  when: "{{ WhenForAdvanced }}"
+  type: bool
+  default: "{{ DefaultForAdvanced }}"
+  help: Add VSCode extension recommendations (Adds a .vscode/extensions.json file recommending the Julia extension)
+  description: |
+    Whether to add a `.vscode/extensions.json` file recommending the [Julia](https://marketplace.visualstudio.com/items?itemName=julialang.language-julia) VS Code extension for the project.
+
+    Strategy: Advanced

--- a/features.toml
+++ b/features.toml
@@ -96,3 +96,10 @@ forced_data = { TestingStrategy = "testitem_cli" }
 included_files = ["test/runtests.jl"]
 required_fields = []
 requires_answers = false
+
+[features.vscode_recommendations]
+description = "Adds `.vscode/extensions.json` recommending the Julia VS Code extension; an existing file is kept unchanged"
+forced_data = { AddVSCodeRecommendations = true }
+included_files = [".vscode/extensions.json"]
+required_fields = []
+requires_answers = false

--- a/python/tests/test_features.py
+++ b/python/tests/test_features.py
@@ -24,6 +24,7 @@ class TestRegistry:
             "pre_commit_with_config",
             "pre_commit_without_config",
             "testitem_cli",
+            "vscode_recommendations",
         ]
 
     def test_every_entry_has_the_expected_keys(self, registry):

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -81,6 +81,7 @@ const strategies = let
       "AddMacToCI" => true,
       "AddPrecommit" => true,
       "AddPrecommitUpdateCI" => true, # actually part of advanced
+      "AddVSCodeRecommendations" => true, # actually part of advanced
       "AddWinToCI" => true,
       "CheckExplicitImports" => true, # actually part of advanced
       "CodeOfConductContact" => split(moderate["Authors"], ",")[1],

--- a/template/{% if AddVSCodeRecommendations %}.vscode{% endif %}/extensions.json.jinja
+++ b/template/{% if AddVSCodeRecommendations %}.vscode{% endif %}/extensions.json.jinja
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "julialang.language-julia"
+  ]
+}

--- a/test/test-add-feature.jl
+++ b/test/test-add-feature.jl
@@ -461,6 +461,26 @@ end
   )
 end
 
+@testitem "add_feature(:vscode_recommendations) generates .vscode/extensions.json" tags =
+  [:integration, :slow, :template_application, :file_io, :python_integration] setup =
+  [Common, AddFeatureHelpers] begin
+  _test_happy_path(
+    :vscode_recommendations,
+    [joinpath(".vscode", "extensions.json")];
+    content_checks = Dict(joinpath(".vscode", "extensions.json") => ["julialang.language-julia"]),
+  )
+end
+
+@testitem "add_feature(:vscode_recommendations) works on an empty folder" tags =
+  [:integration, :slow, :template_application, :file_io, :python_integration] setup =
+  [Common, AddFeatureHelpers] begin
+  _test_works_on_empty_folder(
+    :vscode_recommendations,
+    joinpath(".vscode", "extensions.json");
+    expected_content = "julialang.language-julia",
+  )
+end
+
 @testitem "add_feature errors on unsupported feature symbol" tags = [:unit, :fast, :error_handling] setup =
   [Common, AddFeatureHelpers] begin
   _test_errors_without_data(:nonexistent_feature)

--- a/test/test-add-vscode-recommendations.jl
+++ b/test/test-add-vscode-recommendations.jl
@@ -1,0 +1,21 @@
+@testitem ".vscode/extensions.json is created when AddVSCodeRecommendations is enabled" tags =
+  [:unit, :fast, :file_io] setup = [TestConstants, Common] begin
+  _with_tmp_dir() do dir
+    _generate_test_package(".", TestConstants.args.bestie.robust)
+
+    extensions_path = joinpath(".vscode", "extensions.json")
+    @test isfile(extensions_path)
+    content = read(extensions_path, String)
+    @test contains(content, "julialang.language-julia")
+  end
+end
+
+@testitem ".vscode/extensions.json is absent when AddVSCodeRecommendations is disabled" tags =
+  [:unit, :fast, :file_io] setup = [TestConstants, Common] begin
+  _with_tmp_dir() do dir
+    _generate_test_package(".", TestConstants.args.bestie.tiny)
+
+    @test !isfile(joinpath(".vscode", "extensions.json"))
+    @test !isdir(".vscode")
+  end
+end


### PR DESCRIPTION
Adds an Advanced-strategy question that recommends the Julia VS Code
extension via .vscode/extensions.json, also available as
add_feature(:vscode_recommendations).

Closes #298

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
