### PR TITLE
Make AddPrecommit independent of AddFormatterAndLinterConfigFiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,9 @@ Data merge order (later wins): answers file → guessed from repo → explicit `
 
 Before writing tests, verify the entry matches the template: the `included_files` are gated on the `forced_data` flag (e.g. `{% if MyFlag %}filename{% endif %}.jinja`), and the `required_fields` really are required. Ask the user if anything is ambiguous.
 
+Watch for `when`-clause entanglement before choosing what to force. Copier only persists a question's answer into `.copier-answers.yml` when that question's own `when` evaluates true for the run — a value in `forced_data` still renders correctly this once, but is silently dropped from the answers file if its `when` says no, and a plain `update` will later recompute it from a fallback default. It gets worse when one question's `when` names *another* question's flag: grep `copier/*.yml` for the flag's name, not just its own definition. Forcing that other flag just to keep your feature's `when` open can quietly break persistence for a flag you never meant to touch.
+This chain (`AddPrecommit`'s `when` used to include `AddFormatterAndLinterConfigFiles`) is what caused #625: `pre_commit_without_config` had to force the config-files flag `true` merely so `AddPrecommit` stayed persisted, which meant the config files it was supposed to exclude came back on the next `update`. Don't design a feature around forcing a combination the questionnaire's own `when` chain wouldn't produce on its own — if two questions must be selectable independently via `add_feature`, make their `when` clauses independent too (fix the template, don't route around it with `forced_data`).
+
 Both the `AddFeatureHelpers` snippet and the tests live in `test/test-add-feature.jl`. Which helpers apply depends on `requires_answers` and `required_fields`:
 
 - `_test_happy_path`: feature generates expected file(s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning].
 BREAKING NOTICE
 
 - The `testitem_cli` testing strategy option has changed slightly fixing a bug and removing an unnecessary temporary environment.
+- `add_feature(:pre_commit_with_config)` and `add_feature(:pre_commit_without_config)` have been removed. `add_feature(:pre_commit)` now adds only `.pre-commit-config.yaml`; add the shared formatter/linter configuration files independently with the new `add_feature(:formatter_linter_config)`.
+- `AddPrecommit` is now an independent question from `AddFormatterAndLinterConfigFiles`. If you previously answered `false` to `AddFormatterAndLinterConfigFiles`, you will be asked about `AddPrecommit` again on the next `update`.
 
 ### Added
 
@@ -30,6 +32,7 @@ BREAKING NOTICE
 ### Fixed
 
 - The filter flags of the `testitem_cli` test runner now work when the tests are run through `Pkg.test`, which includes `test/runtests.jl` instead of executing it as a program. Filters passed as `test_args` were previously ignored, and so were misspelled flags, both without any warning. This affects `pkg> test` and `julia-actions/julia-runtest` as well (#640)
+- The `AddPrecommit` question no longer depends on `AddFormatterAndLinterConfigFiles`. The two were entangled so that declining the config files also silently defaulted away pre-commit, which forced `add_feature(:pre_commit_without_config)` to record `AddFormatterAndLinterConfigFiles = true` just to keep pre-commit's own answer remembered — and a later plain `update` would then restore the config files the feature was meant to leave out (#625)
 
 ## [0.19.0] - 2026-08-02
 

--- a/copier/code-quality.yml
+++ b/copier/code-quality.yml
@@ -18,7 +18,7 @@ AddFormatterAndLinterConfigFiles:
     Strategy: Light
 
 AddPrecommit:
-  when: "{{ AddFormatterAndLinterConfigFiles and WhenForModerate }}"
+  when: "{{ WhenForModerate }}"
   type: bool
   default: "{{ DefaultForModerate }}"
   help: Pre-commit (Whether to add pre-commit.org. It runs before every commit fixing your formatting and preventing bad practices)

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -469,6 +469,9 @@ AddMyFeature:
     The [Questions](@ref) page parses the `copier/*.yml` files and looks for `Strategy: <Level>` inside every `description`.
     A question outside `essential.yml` and `strategy.yml` without that line makes the documentation build fail.
 
+!!! warning "Don't chain `when` clauses across questions"
+    If question B's `when` depends on question A's flag, forcing A just to keep B's `when` open also persists A's forced value into `.copier-answers.yml` — even if that's not the value you wanted remembered for A. That's what caused #625: forcing `AddFormatterAndLinterConfigFiles = true` so `AddPrecommit` would persist also persisted the config-files flag as `true`, bringing back files a feature meant to exclude. Keep `when` clauses independent whenever two questions must be selectable separately through `add_feature`.
+
 Optional fields, when they apply: `choices:` (a map of `"Display name": value`), `validator:` (a Jinja2 expression that returns an empty string when the answer is valid), and `placeholder:`.
 If you think your question needs one of these, look at the existing questions first — `TestingStrategy` and `License` for `choices`, `PackageName` and `JuliaIndentation` for `validator`, and `Authors` for `placeholder` — and follow the closest one.
 

--- a/features.toml
+++ b/features.toml
@@ -67,26 +67,22 @@ required_fields = ["AddPrecommit", "AddLychee"]
 requires_answers = false
 
 [features.pre_commit]
-alias_of = "pre_commit_with_config"
+description = "Adds `.pre-commit-config.yaml`. Combine with `:formatter_linter_config` to also add the shared formatter/linter configuration files; pre-commit's hooks fall back to each tool's own defaults without them"
+forced_data = { AddPrecommit = true }
+included_files = [".pre-commit-config.yaml"]
+required_fields = []
+requires_answers = false
 
-[features.pre_commit_with_config]
-description = "Adds `.pre-commit-config.yaml` and the formatter/linter configuration files"
-forced_data = { AddPrecommit = true, AddFormatterAndLinterConfigFiles = true }
+[features.formatter_linter_config]
+description = "Adds the formatter/linter configuration files (`.JuliaFormatter.toml`, `.editorconfig`, `.yamlfmt.yml`, `.yamllint.yml`, `.markdownlint.json`); picked up by editors directly and by pre-commit's hooks if `:pre_commit` is also added"
+forced_data = { AddFormatterAndLinterConfigFiles = true }
 included_files = [
-  ".pre-commit-config.yaml",
   ".JuliaFormatter.toml",
   ".editorconfig",
   ".yamlfmt.yml",
   ".yamllint.yml",
   ".markdownlint.json",
 ]
-required_fields = []
-requires_answers = false
-
-[features.pre_commit_without_config]
-description = "Adds only `.pre-commit-config.yaml`, without the formatter/linter configuration files"
-forced_data = { AddPrecommit = true, AddFormatterAndLinterConfigFiles = true }
-included_files = [".pre-commit-config.yaml"]
 required_fields = []
 requires_answers = false
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -79,11 +79,21 @@ class TestAddFeature:
 
 
 class TestListFeatures:
-    def test_lists_descriptions_and_aliases(self):
+    def test_lists_descriptions_and_aliases(self, monkeypatch):
+        # No entry in the real registry is currently an alias (#625 removed the last
+        # one); exercise the CLI's rendering of both shapes directly.
+        monkeypatch.setattr(
+            bestie_template.cli,
+            "list_features",
+            lambda: [
+                {"name": "agents", "description": "Adds AGENTS.md"},
+                {"name": "pre_commit_alias", "alias_of": "pre_commit"},
+            ],
+        )
         result = runner.invoke(app, ["list-features"])
         assert result.exit_code == 0
-        assert "agents" in result.stdout
-        assert "alias of pre_commit_with_config" in result.stdout
+        assert "Adds AGENTS.md" in result.stdout
+        assert "alias of pre_commit" in result.stdout
 
     def test_json_lists_every_entry(self, registry):
         result = runner.invoke(app, ["list-features", "--json"])

--- a/python/tests/test_features.py
+++ b/python/tests/test_features.py
@@ -18,11 +18,10 @@ class TestRegistry:
             "agents",
             "changelog",
             "dependabot",
+            "formatter_linter_config",
             "lint_action",
             "lint_action_explicit",
             "pre_commit",
-            "pre_commit_with_config",
-            "pre_commit_without_config",
             "testitem_cli",
             "vscode_recommendations",
         ]
@@ -53,9 +52,21 @@ class TestRegistry:
                 assert files and all(isinstance(file, str) for file in files), name
             assert spec["description"] and spec["included_files"]
 
-    def test_aliases_resolve(self, registry):
-        resolved = bestie_template._resolve(registry, "pre_commit")
-        assert resolved is registry["pre_commit_with_config"]
+    def test_aliases_resolve(self):
+        # No entry in the real registry is currently an alias (#625 removed the last
+        # one); exercise the generic resolution mechanism with a synthetic registry.
+        synthetic = {
+            "my_alias": {"alias_of": "real_feature"},
+            "real_feature": {
+                "description": "d",
+                "forced_data": {},
+                "included_files": ["f"],
+                "required_fields": [],
+                "requires_answers": False,
+            },
+        }
+        resolved = bestie_template._resolve(synthetic, "my_alias")
+        assert resolved is synthetic["real_feature"]
 
     def test_unknown_feature_lists_the_supported_ones(self, registry):
         with pytest.raises(BestieError, match=r"Unknown feature 'nope'.*agents"):
@@ -70,7 +81,6 @@ class TestRegistry:
     def test_list_features_is_sorted_and_json_ready(self, registry):
         features = list_features(registry)
         assert [feature["name"] for feature in features] == sorted(registry)
-        assert {"name": "pre_commit", "alias_of": "pre_commit_with_config"} in features
 
 
 def test_license_matches_the_repo(repo_root):
@@ -86,7 +96,7 @@ class TestAddFeature:
         (call,) = copier_calls
         assert call["exclude"][0] == "**"
         assert set(call["exclude"][1:]) == {
-            f"!{file}" for file in registry["pre_commit_with_config"]["included_files"]
+            f"!{file}" for file in registry["pre_commit"]["included_files"]
         }
 
     def test_data_merge_order_and_placeholders(self, tmp_path, registry, copier_calls):
@@ -207,7 +217,7 @@ class TestAgainstTheRealTemplate:
 
     def test_only_the_features_files_are_written(self, tmp_path, template):
         add_feature(
-            ["agents", "pre_commit"],
+            ["agents", "pre_commit", "formatter_linter_config"],
             tmp_path,
             {"PackageName": "FakePkg"},
             template=template,

--- a/skills/bestie-features/SKILL.md
+++ b/skills/bestie-features/SKILL.md
@@ -52,7 +52,7 @@ When asked what a package could use rather than for a named feature, start from 
 
 ## Protected files
 
-The template's `_skip_if_exists` list decides whether an existing file is preserved or replaced; it is not a per-feature property. Of the files the features own, only `AGENTS.md` and `CHANGELOG.md` are on that list — so `agents` and `changelog` never touch an existing file, while `dependabot`, `lint_action`, `pre_commit*` and `testitem_cli` overwrite theirs. `test/runtests.jl` is an explicit exception carved out of the list's blanket protection for `**/*.jl`, which is why the test runner is replaceable at all.
+The template's `_skip_if_exists` list decides whether an existing file is preserved or replaced; it is not a per-feature property. Of the files the features own, only `AGENTS.md` and `CHANGELOG.md` are on that list — so `agents` and `changelog` never touch an existing file, while `dependabot`, `lint_action`, `pre_commit`, `formatter_linter_config` and `testitem_cli` overwrite theirs. `test/runtests.jl` is an explicit exception carved out of the list's blanket protection for `**/*.jl`, which is why the test runner is replaceable at all.
 
 Both outcomes print the same "Applied N feature(s)" line, so read the diff rather than the output. Two consequences to pass on to the user:
 

--- a/test/test-add-feature.jl
+++ b/test/test-add-feature.jl
@@ -230,19 +230,15 @@ end
   )
 end
 
-@testitem "add_feature(:pre_commit) generates pre-commit config and linter files" tags =
+@testitem "add_feature(:pre_commit) generates only .pre-commit-config.yaml" tags =
   [:integration, :slow, :template_application, :file_io, :python_integration] setup =
   [Common, AddFeatureHelpers] begin
+  # AddPrecommit and AddFormatterAndLinterConfigFiles are independent questions (#625):
+  # adding pre-commit must not also pull in the formatter/linter config files.
   _test_happy_path(
     :pre_commit,
-    [
-      ".pre-commit-config.yaml",
-      ".JuliaFormatter.toml",
-      ".editorconfig",
-      ".yamlfmt.yml",
-      ".yamllint.yml",
-      ".markdownlint.json",
-    ],
+    [".pre-commit-config.yaml"];
+    unexpected_files = [".JuliaFormatter.toml"],
   )
 end
 
@@ -252,20 +248,26 @@ end
   _test_works_on_empty_folder(:pre_commit, ".pre-commit-config.yaml")
 end
 
-@testitem "add_feature(:pre_commit_without_config) generates only .pre-commit-config.yaml" tags =
+@testitem "add_feature(:formatter_linter_config) generates the formatter/linter config files" tags =
   [:integration, :slow, :template_application, :file_io, :python_integration] setup =
   [Common, AddFeatureHelpers] begin
   _test_happy_path(
-    :pre_commit_without_config,
-    [".pre-commit-config.yaml"];
-    unexpected_files = [".JuliaFormatter.toml"],
+    :formatter_linter_config,
+    [
+      ".JuliaFormatter.toml",
+      ".editorconfig",
+      ".yamlfmt.yml",
+      ".yamllint.yml",
+      ".markdownlint.json",
+    ];
+    unexpected_files = [".pre-commit-config.yaml"],
   )
 end
 
-@testitem "add_feature(:pre_commit_without_config) works on an empty folder" tags =
+@testitem "add_feature(:formatter_linter_config) works on an empty folder" tags =
   [:integration, :slow, :template_application, :file_io, :python_integration] setup =
   [Common, AddFeatureHelpers] begin
-  _test_works_on_empty_folder(:pre_commit_without_config, ".pre-commit-config.yaml")
+  _test_works_on_empty_folder(:formatter_linter_config, ".JuliaFormatter.toml")
 end
 
 @testitem "add_feature(:lint_action) generates Lint.yml workflow" tags =
@@ -512,6 +514,7 @@ end
 
   # The docstring generator must produce the real list, not the error fallback
   @test contains(BestieTemplate._features_docstring(), ":pre_commit")
+  @test contains(BestieTemplate._features_docstring(), ":formatter_linter_config")
 end
 
 @testitem "the features.toml loader rejects malformed registries" tags =


### PR DESCRIPTION
AddPrecommit's `when` was chained to AddFormatterAndLinterConfigFiles, so
add_feature(:pre_commit_without_config) had to force the config-files flag
true just to keep pre-commit's own answer persisted in .copier-answers.yml
- which brought the declined config files back on the next `update`. Decouple
the two questions and replace the with/without-config features with
independent `pre_commit` and `formatter_linter_config` entries.

Closes #625

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Umz435YRYEVTHkjJ6ZoyN
