### PR TITLE
Document adding features via bestie CLI and add_feature in the quick guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ uvx --from bestie-template bestie list-features
 uvx --from bestie-template bestie add-feature changelog,dependabot path/to/MyPackage.jl
 ```
 
+See the [quick guide](https://JuliaBesties.github.io/BestieTemplate.jl/stable/10-guides/05-quick-guide/#Adding-features-directly-via-bestie-CLI) for more details, and its [`add_feature`](https://JuliaBesties.github.io/BestieTemplate.jl/stable/10-guides/05-quick-guide/#Adding-a-single-feature-with-add_feature) counterpart for the Julia version.
+
 For AI coding agents, the same workflow is packaged as the [`bestie-features` skill](skills/bestie-features/SKILL.md), which is installable with
 
 ```sh

--- a/docs/src/10-guides/05-quick-guide.md
+++ b/docs/src/10-guides/05-quick-guide.md
@@ -264,3 +264,62 @@ new_pkg_quick(
 visited = tree_of_folder(pkg_destination, String[]) # hide
 nothing # hide
 ```
+
+## Adding features directly via bestie CLI
+
+If you only want one or two files from the template — a `CHANGELOG.md`, a `dependabot.yml`, a pre-commit config — without installing Julia or going through the full `apply`/`update` flow, use the experimental [`bestie-template`](https://pypi.org/p/bestie-template) Python package. It only needs [uv](https://docs.astral.sh/uv/) on the `PATH`, no install step required:
+
+```sh
+uvx --from bestie-template bestie list-features
+uvx --from bestie-template bestie add-feature changelog,dependabot path/to/MyPackage.jl
+```
+
+(`--from bestie-template` is needed because the PyPI package is named `bestie-template`, while the command it installs is `bestie`.)
+
+`list-features` prints every feature `bestie` can add, along with the answers each one needs and the files it writes; pass `--json` for a machine-readable version. `add-feature` then applies one or more features (comma-separated, no spaces) to the package at the given path — each feature writes only the files it owns, leaving the rest of the package untouched.
+
+A few things worth knowing before running it:
+
+- **It overwrites without asking.** A feature replaces its own files outright — no diff, no conflict prompt, no backup. Commit or stash first, so `git diff`/`git checkout` remains your way to undo it.
+- **Some features need existing answers.** A few features (e.g. `lint_action`) read `.copier-answers.yml` to decide what to render, and refuse to run without it. Check `list-features --json` for an `_explicit` variant first — it takes the same information as `-d KEY=VALUE` flags instead.
+- **Version pinning.** `--ref vX.Y.Z` pins the template version used to render the feature; omit it to use the latest release, or pass `--ref main` for a feature that has not shipped in a release yet.
+
+For AI coding agents, this same workflow is packaged as the [`bestie-features` skill](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/skills/bestie-features/SKILL.md), which teaches an agent the feature names, how to resolve the answers each one needs, and the follow-up work some features require. Install it with [`npx skills add JuliaBesties/BestieTemplate.jl`](https://www.skills.sh).
+
+## Adding a single feature with `add_feature`
+
+The same idea is available from Julia, through [`BestieTemplate.add_feature`](@ref): apply one named slice of the template — say, just the changelog — to an existing package, without going through the full `apply`/`update` flow.
+
+Here, `AnswerPackage.jl` already has a `.copier-answers.yml` (from `new_pkg_quick`/`generate`/`apply`), so `add_feature` reads the answers it needs — `PackageOwner`, `PackageName` — straight from it:
+
+```@example quick_start_guide
+using BestieTemplate: add_feature
+
+pkg_destination = joinpath(root_dir, "AnswerPackage.jl")
+package_owner = "JuliaBesties" # hide
+authors = "JuliaBesties maintainers" # hide
+new_pkg_quick(pkg_destination, package_owner, authors, :tiny, template_source = :local, use_latest = true) # hide
+
+add_feature(
+    :changelog,
+    pkg_destination,
+    template_source = :local, # hide
+    use_latest = true, # hide
+)
+
+# Resulting folder: (Notice the new CHANGELOG.md)
+visited = tree_of_folder(pkg_destination, String[]) # hide
+nothing # hide
+```
+
+On a package with no `.copier-answers.yml`, `add_feature` still guesses what it can from the package itself — `PackageName`, `Authors` and `JuliaMinVersion` from `Project.toml`, `PackageOwner` from `docs/make.jl` if present, indentation from `.JuliaFormatter.toml` — and only complains about what's left. For a `:tiny` package, which has no `docs/make.jl`, that's `PackageOwner`:
+
+```julia-repl
+julia> add_feature(:changelog, pkg_destination)
+ERROR: Cannot determine required fields: PackageOwner.
+      Pass them via the `data` argument or run `BestieTemplate.apply` first.
+```
+
+Pass whatever it names through the `data` argument: `add_feature(:changelog, pkg_destination, Dict("PackageOwner" => "JuliaBesties"))`.
+
+As with `add-feature` from the CLI, this overwrites the feature's files outright, and a git repository is your only way to undo it. See the [`BestieTemplate.add_feature`](@ref) docstring for the full list of features and their required answers, and the [Full guide](@ref full_guide) for how the recorded template version is affected.


### PR DESCRIPTION
Covers the non-Julia bestie CLI workflow (list-features/add-feature,
overwrite behavior, version pinning, the bestie-features skill) and a
runnable add_feature example, including what it can guess from an
existing package versus what must be passed explicitly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
